### PR TITLE
faster skipping long numbers

### DIFF
--- a/array_handler_machine.rl.go
+++ b/array_handler_machine.rl.go
@@ -9,11 +9,11 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	eof := len(data)
 
 	const handleArrayValues_start int = 1
-	const handleArrayValues_first_final int = 263
+	const handleArrayValues_first_final int = 243
 	const handleArrayValues_error int = 0
 
 	const handleArrayValues_en_skip_array int = 83
-	const handleArrayValues_en_skip_object int = 160
+	const handleArrayValues_en_skip_object int = 150
 	const handleArrayValues_en_main int = 1
 
 	{
@@ -57,8 +57,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st12
 		case 13:
 			goto st13
-		case 263:
-			goto st263
+		case 243:
+			goto st243
 		case 14:
 			goto st14
 		case 15:
@@ -197,8 +197,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st81
 		case 82:
 			goto st82
-		case 264:
-			goto st264
+		case 244:
+			goto st244
 		case 83:
 			goto st83
 		case 84:
@@ -221,8 +221,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st92
 		case 93:
 			goto st93
-		case 265:
-			goto st265
+		case 245:
+			goto st245
 		case 94:
 			goto st94
 		case 95:
@@ -381,6 +381,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st171
 		case 172:
 			goto st172
+		case 246:
+			goto st246
 		case 173:
 			goto st173
 		case 174:
@@ -401,8 +403,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st181
 		case 182:
 			goto st182
-		case 266:
-			goto st266
 		case 183:
 			goto st183
 		case 184:
@@ -523,46 +523,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st241
 		case 242:
 			goto st242
-		case 243:
-			goto st243
-		case 244:
-			goto st244
-		case 245:
-			goto st245
-		case 246:
-			goto st246
-		case 247:
-			goto st247
-		case 248:
-			goto st248
-		case 249:
-			goto st249
-		case 250:
-			goto st250
-		case 251:
-			goto st251
-		case 252:
-			goto st252
-		case 253:
-			goto st253
-		case 254:
-			goto st254
-		case 255:
-			goto st255
-		case 256:
-			goto st256
-		case 257:
-			goto st257
-		case 258:
-			goto st258
-		case 259:
-			goto st259
-		case 260:
-			goto st260
-		case 261:
-			goto st261
-		case 262:
-			goto st262
 		}
 
 		if p++; p == pe {
@@ -598,8 +558,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_12
 		case 13:
 			goto st_case_13
-		case 263:
-			goto st_case_263
+		case 243:
+			goto st_case_243
 		case 14:
 			goto st_case_14
 		case 15:
@@ -738,8 +698,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_81
 		case 82:
 			goto st_case_82
-		case 264:
-			goto st_case_264
+		case 244:
+			goto st_case_244
 		case 83:
 			goto st_case_83
 		case 84:
@@ -762,8 +722,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_92
 		case 93:
 			goto st_case_93
-		case 265:
-			goto st_case_265
+		case 245:
+			goto st_case_245
 		case 94:
 			goto st_case_94
 		case 95:
@@ -922,6 +882,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_171
 		case 172:
 			goto st_case_172
+		case 246:
+			goto st_case_246
 		case 173:
 			goto st_case_173
 		case 174:
@@ -942,8 +904,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_181
 		case 182:
 			goto st_case_182
-		case 266:
-			goto st_case_266
 		case 183:
 			goto st_case_183
 		case 184:
@@ -1064,46 +1024,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st_case_241
 		case 242:
 			goto st_case_242
-		case 243:
-			goto st_case_243
-		case 244:
-			goto st_case_244
-		case 245:
-			goto st_case_245
-		case 246:
-			goto st_case_246
-		case 247:
-			goto st_case_247
-		case 248:
-			goto st_case_248
-		case 249:
-			goto st_case_249
-		case 250:
-			goto st_case_250
-		case 251:
-			goto st_case_251
-		case 252:
-			goto st_case_252
-		case 253:
-			goto st_case_253
-		case 254:
-			goto st_case_254
-		case 255:
-			goto st_case_255
-		case 256:
-			goto st_case_256
-		case 257:
-			goto st_case_257
-		case 258:
-			goto st_case_258
-		case 259:
-			goto st_case_259
-		case 260:
-			goto st_case_260
-		case 261:
-			goto st_case_261
-		case 262:
-			goto st_case_262
 		}
 		goto st_out
 	st1:
@@ -1138,7 +1058,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _out
 		}
 		goto st0
-	tr166:
+	tr156:
 		err = errInvalidObject
 		{
 			p++
@@ -1188,7 +1108,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 91:
 			goto tr9
 		case 93:
-			goto st263
+			goto st243
 		case 102:
 			goto tr11
 		case 110:
@@ -1226,7 +1146,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 91:
 			goto tr9
 		case 93:
-			goto st263
+			goto st243
 		case 102:
 			goto tr11
 		case 110:
@@ -1316,7 +1236,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -1335,7 +1255,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -1484,17 +1404,17 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
 		}
 		goto tr0
-	st263:
+	st243:
 		if p++; p == pe {
-			goto _test_eof263
+			goto _test_eof243
 		}
-	st_case_263:
+	st_case_243:
 		goto st0
 	st14:
 		if p++; p == pe {
@@ -1669,7 +1589,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st26
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st26
 		}
@@ -1701,7 +1621,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st26
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st26
 		}
@@ -1729,7 +1649,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st26
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st26
 		}
@@ -1779,7 +1699,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		switch {
 		case data[p] > 10:
@@ -1803,7 +1723,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		switch {
 		case data[p] > 10:
@@ -1839,7 +1759,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st26
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st26
 		}
@@ -1869,7 +1789,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st26
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st26
 		}
@@ -1933,7 +1853,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -1996,7 +1916,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2050,7 +1970,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2104,7 +2024,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2144,7 +2064,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			{
 				stack[top] = 46
 				top++
-				goto st160
+				goto st150
 			}
 		}
 		goto st46
@@ -2161,7 +2081,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2340,7 +2260,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st59
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st59
 		}
@@ -2372,7 +2292,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st59
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st59
 		}
@@ -2400,7 +2320,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st59
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st59
 		}
@@ -2450,7 +2370,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		switch {
 		case data[p] > 10:
@@ -2474,7 +2394,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		switch {
 		case data[p] > 10:
@@ -2510,7 +2430,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st59
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st59
 		}
@@ -2540,7 +2460,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 69:
 			goto st59
 		case 93:
-			goto st263
+			goto st243
 		case 101:
 			goto st59
 		}
@@ -2604,7 +2524,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2667,7 +2587,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2721,7 +2641,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2775,7 +2695,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2815,7 +2735,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			{
 				stack[top] = 79
 				top++
-				goto st160
+				goto st150
 			}
 		}
 		goto st79
@@ -2832,7 +2752,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st9
 		case 93:
-			goto st263
+			goto st243
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st8
@@ -2862,14 +2782,14 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		}
 	st_case_82:
 		if data[p] == 108 {
-			goto st264
+			goto st244
 		}
 		goto tr0
-	st264:
+	st244:
 		if p++; p == pe {
-			goto _test_eof264
+			goto _test_eof244
 		}
-	st_case_264:
+	st_case_244:
 		goto st0
 	st83:
 		if p++; p == pe {
@@ -2884,26 +2804,26 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 34:
 			goto st85
 		case 45:
-			goto st134
+			goto st129
 		case 48:
-			goto st135
+			goto st130
 		case 91:
 			goto tr94
 		case 93:
 			goto tr95
 		case 102:
-			goto st146
+			goto st136
 		case 110:
-			goto st151
+			goto st141
 		case 116:
-			goto st155
+			goto st145
 		case 123:
 			goto tr99
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st143
+				goto st133
 			}
 		case data[p] >= 9:
 			goto st84
@@ -2922,26 +2842,26 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 34:
 			goto st85
 		case 45:
-			goto st134
+			goto st129
 		case 48:
-			goto st135
+			goto st130
 		case 91:
 			goto tr94
 		case 93:
 			goto tr95
 		case 102:
-			goto st146
+			goto st136
 		case 110:
-			goto st151
+			goto st141
 		case 116:
-			goto st155
+			goto st145
 		case 123:
 			goto tr99
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st143
+				goto st133
 			}
 		case data[p] >= 9:
 			goto st84
@@ -2956,7 +2876,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 34:
 			goto st87
 		case 92:
-			goto st127
+			goto st122
 		}
 		if data[p] <= 31 {
 			goto tr88
@@ -2971,7 +2891,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 34:
 			goto st87
 		case 92:
-			goto st127
+			goto st122
 		}
 		if data[p] <= 31 {
 			goto tr88
@@ -3034,18 +2954,18 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 91:
 			goto tr110
 		case 102:
-			goto st113
+			goto st108
 		case 110:
-			goto st118
+			goto st113
 		case 116:
-			goto st122
+			goto st117
 		case 123:
 			goto tr114
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st110
+				goto st105
 			}
 		case data[p] >= 9:
 			goto st90
@@ -3070,18 +2990,18 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 91:
 			goto tr110
 		case 102:
-			goto st113
+			goto st108
 		case 110:
-			goto st118
+			goto st113
 		case 116:
-			goto st122
+			goto st117
 		case 123:
 			goto tr114
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st110
+				goto st105
 			}
 		case data[p] >= 9:
 			goto st90
@@ -3142,12 +3062,12 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			cs = stack[top]
 			goto _again
 		}
-		goto st265
-	st265:
+		goto st245
+	st245:
 		if p++; p == pe {
-			goto _test_eof265
+			goto _test_eof245
 		}
-	st_case_265:
+	st_case_245:
 		goto st0
 	st94:
 		if p++; p == pe {
@@ -3286,7 +3206,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st102
 		}
 		if 49 <= data[p] && data[p] <= 57 {
-			goto st110
+			goto st105
 		}
 		goto tr88
 	st102:
@@ -3302,27 +3222,43 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st89
 		case 46:
-			goto st103
+			goto tr124
 		case 69:
-			goto st106
+			goto tr125
 		case 93:
 			goto tr95
 		case 101:
-			goto st106
+			goto tr125
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st88
 		}
 		goto tr88
+	tr124:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st103
 	st103:
 		if p++; p == pe {
 			goto _test_eof103
 		}
 	st_case_103:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st104
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
+	tr125:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st104
 	st104:
 		if p++; p == pe {
 			goto _test_eof104
@@ -3335,19 +3271,10 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		case 44:
 			goto st89
-		case 69:
-			goto st106
 		case 93:
 			goto tr95
-		case 101:
-			goto st106
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st105
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st88
 		}
 		goto tr88
@@ -3363,17 +3290,19 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		case 44:
 			goto st89
+		case 46:
+			goto tr124
 		case 69:
-			goto st106
+			goto tr125
 		case 93:
 			goto tr95
 		case 101:
-			goto st106
+			goto tr125
 		}
 		switch {
 		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st105
+				goto st106
 			}
 		case data[p] >= 9:
 			goto st88
@@ -3385,78 +3314,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		}
 	st_case_106:
 		switch data[p] {
-		case 43:
-			goto st107
-		case 45:
-			goto st107
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st108
-		}
-		goto tr88
-	st107:
-		if p++; p == pe {
-			goto _test_eof107
-		}
-	st_case_107:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st108
-		}
-		goto tr88
-	st108:
-		if p++; p == pe {
-			goto _test_eof108
-		}
-	st_case_108:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st109
-			}
-		case data[p] >= 9:
-			goto st88
-		}
-		goto tr88
-	st109:
-		if p++; p == pe {
-			goto _test_eof109
-		}
-	st_case_109:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st109
-			}
-		case data[p] >= 9:
-			goto st88
-		}
-		goto tr88
-	st110:
-		if p++; p == pe {
-			goto _test_eof110
-		}
-	st_case_110:
-		switch data[p] {
 		case 13:
 			goto st88
 		case 32:
@@ -3464,48 +3321,18 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 44:
 			goto st89
 		case 46:
-			goto st103
+			goto tr124
 		case 69:
-			goto st106
+			goto tr125
 		case 93:
 			goto tr95
 		case 101:
-			goto st106
+			goto tr125
 		}
 		switch {
 		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st111
-			}
-		case data[p] >= 9:
-			goto st88
-		}
-		goto tr88
-	st111:
-		if p++; p == pe {
-			goto _test_eof111
-		}
-	st_case_111:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 46:
-			goto st103
-		case 69:
-			goto st106
-		case 93:
-			goto tr95
-		case 101:
-			goto st106
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st111
+				goto st106
 			}
 		case data[p] >= 9:
 			goto st88
@@ -3517,12 +3344,67 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 112
+				stack[top] = 107
 				top++
 				goto st83
 			}
 		}
-		goto st112
+		goto st107
+	st107:
+		if p++; p == pe {
+			goto _test_eof107
+		}
+	st_case_107:
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
+		}
+		goto tr88
+	st108:
+		if p++; p == pe {
+			goto _test_eof108
+		}
+	st_case_108:
+		if data[p] == 97 {
+			goto st109
+		}
+		goto tr88
+	st109:
+		if p++; p == pe {
+			goto _test_eof109
+		}
+	st_case_109:
+		if data[p] == 108 {
+			goto st110
+		}
+		goto tr88
+	st110:
+		if p++; p == pe {
+			goto _test_eof110
+		}
+	st_case_110:
+		if data[p] == 115 {
+			goto st111
+		}
+		goto tr88
+	st111:
+		if p++; p == pe {
+			goto _test_eof111
+		}
+	st_case_111:
+		if data[p] == 101 {
+			goto st112
+		}
+		goto tr88
 	st112:
 		if p++; p == pe {
 			goto _test_eof112
@@ -3547,7 +3429,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof113
 		}
 	st_case_113:
-		if data[p] == 97 {
+		if data[p] == 117 {
 			goto st114
 		}
 		goto tr88
@@ -3565,7 +3447,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof115
 		}
 	st_case_115:
-		if data[p] == 115 {
+		if data[p] == 108 {
 			goto st116
 		}
 		goto tr88
@@ -3574,15 +3456,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof116
 		}
 	st_case_116:
-		if data[p] == 101 {
-			goto st117
-		}
-		goto tr88
-	st117:
-		if p++; p == pe {
-			goto _test_eof117
-		}
-	st_case_117:
 		switch data[p] {
 		case 13:
 			goto st88
@@ -3595,6 +3468,15 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st88
+		}
+		goto tr88
+	st117:
+		if p++; p == pe {
+			goto _test_eof117
+		}
+	st_case_117:
+		if data[p] == 114 {
+			goto st118
 		}
 		goto tr88
 	st118:
@@ -3611,7 +3493,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof119
 		}
 	st_case_119:
-		if data[p] == 108 {
+		if data[p] == 101 {
 			goto st120
 		}
 		goto tr88
@@ -3620,10 +3502,32 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof120
 		}
 	st_case_120:
-		if data[p] == 108 {
-			goto st121
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
+	tr114:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 121
+				top++
+				goto st150
+			}
+		}
+		goto st121
 	st121:
 		if p++; p == pe {
 			goto _test_eof121
@@ -3648,8 +3552,25 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof122
 		}
 	st_case_122:
-		if data[p] == 114 {
+		switch data[p] {
+		case 34:
 			goto st123
+		case 47:
+			goto st123
+		case 92:
+			goto st123
+		case 98:
+			goto st123
+		case 102:
+			goto st123
+		case 110:
+			goto st123
+		case 114:
+			goto st123
+		case 116:
+			goto st123
+		case 117:
+			goto st124
 		}
 		goto tr88
 	st123:
@@ -3657,16 +3578,31 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof123
 		}
 	st_case_123:
-		if data[p] == 117 {
-			goto st124
+		switch data[p] {
+		case 34:
+			goto st87
+		case 92:
+			goto st122
 		}
-		goto tr88
+		if data[p] <= 31 {
+			goto tr88
+		}
+		goto st86
 	st124:
 		if p++; p == pe {
 			goto _test_eof124
 		}
 	st_case_124:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st125
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st125
+			}
+		default:
 			goto st125
 		}
 		goto tr88
@@ -3675,49 +3611,35 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof125
 		}
 	st_case_125:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st88
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st126
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st126
+			}
+		default:
+			goto st126
 		}
 		goto tr88
-	tr114:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 126
-				top++
-				goto st160
-			}
-		}
-		goto st126
 	st126:
 		if p++; p == pe {
 			goto _test_eof126
 		}
 	st_case_126:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st88
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st127
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st127
+			}
+		default:
+			goto st127
 		}
 		goto tr88
 	st127:
@@ -3725,25 +3647,17 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof127
 		}
 	st_case_127:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st128
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st128
+			}
+		default:
 			goto st128
-		case 47:
-			goto st128
-		case 92:
-			goto st128
-		case 98:
-			goto st128
-		case 102:
-			goto st128
-		case 110:
-			goto st128
-		case 114:
-			goto st128
-		case 116:
-			goto st128
-		case 117:
-			goto st129
 		}
 		goto tr88
 	st128:
@@ -3755,7 +3669,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		case 34:
 			goto st87
 		case 92:
-			goto st127
+			goto st122
 		}
 		if data[p] <= 31 {
 			goto tr88
@@ -3766,17 +3680,11 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof129
 		}
 	st_case_129:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st130
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st130
-			}
-		default:
+		if data[p] == 48 {
 			goto st130
+		}
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st133
 		}
 		goto tr88
 	st130:
@@ -3784,53 +3692,68 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof130
 		}
 	st_case_130:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st131
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st131
-			}
-		default:
-			goto st131
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 46:
+			goto tr143
+		case 69:
+			goto tr144
+		case 93:
+			goto tr95
+		case 101:
+			goto tr144
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
+	tr143:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st131
 	st131:
 		if p++; p == pe {
 			goto _test_eof131
 		}
 	st_case_131:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st132
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st132
-			}
-		default:
-			goto st132
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
+	tr144:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st132
 	st132:
 		if p++; p == pe {
 			goto _test_eof132
 		}
 	st_case_132:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st133
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st133
-			}
-		default:
-			goto st133
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
 	st133:
@@ -3839,27 +3762,72 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		}
 	st_case_133:
 		switch data[p] {
-		case 34:
-			goto st87
-		case 92:
-			goto st127
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 46:
+			goto tr143
+		case 69:
+			goto tr144
+		case 93:
+			goto tr95
+		case 101:
+			goto tr144
 		}
-		if data[p] <= 31 {
-			goto tr88
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st134
+			}
+		case data[p] >= 9:
+			goto st88
 		}
-		goto st86
+		goto tr88
 	st134:
 		if p++; p == pe {
 			goto _test_eof134
 		}
 	st_case_134:
-		if data[p] == 48 {
-			goto st135
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 46:
+			goto tr143
+		case 69:
+			goto tr144
+		case 93:
+			goto tr95
+		case 101:
+			goto tr144
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st143
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st134
+			}
+		case data[p] >= 9:
+			goto st88
 		}
 		goto tr88
+	tr94:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 135
+				top++
+				goto st83
+			}
+		}
+		goto st135
 	st135:
 		if p++; p == pe {
 			goto _test_eof135
@@ -3872,14 +3840,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		case 44:
 			goto st89
-		case 46:
-			goto st136
-		case 69:
-			goto st139
 		case 93:
 			goto tr95
-		case 101:
-			goto st139
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st88
@@ -3890,7 +3852,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof136
 		}
 	st_case_136:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 97 {
 			goto st137
 		}
 		goto tr88
@@ -3899,27 +3861,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof137
 		}
 	st_case_137:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 69:
-			goto st139
-		case 93:
-			goto tr95
-		case 101:
-			goto st139
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st138
-			}
-		case data[p] >= 9:
-			goto st88
+		if data[p] == 108 {
+			goto st138
 		}
 		goto tr88
 	st138:
@@ -3927,27 +3870,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof138
 		}
 	st_case_138:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 69:
+		if data[p] == 115 {
 			goto st139
-		case 93:
-			goto tr95
-		case 101:
-			goto st139
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st138
-			}
-		case data[p] >= 9:
-			goto st88
 		}
 		goto tr88
 	st139:
@@ -3955,14 +3879,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof139
 		}
 	st_case_139:
-		switch data[p] {
-		case 43:
+		if data[p] == 101 {
 			goto st140
-		case 45:
-			goto st140
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st141
 		}
 		goto tr88
 	st140:
@@ -3970,8 +3888,18 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof140
 		}
 	st_case_140:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st141
+		switch data[p] {
+		case 13:
+			goto st88
+		case 32:
+			goto st88
+		case 44:
+			goto st89
+		case 93:
+			goto tr95
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st88
 		}
 		goto tr88
 	st141:
@@ -3979,23 +3907,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof141
 		}
 	st_case_141:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st142
-			}
-		case data[p] >= 9:
-			goto st88
+		if data[p] == 117 {
+			goto st142
 		}
 		goto tr88
 	st142:
@@ -4003,23 +3916,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof142
 		}
 	st_case_142:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st142
-			}
-		case data[p] >= 9:
-			goto st88
+		if data[p] == 108 {
+			goto st143
 		}
 		goto tr88
 	st143:
@@ -4027,29 +3925,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof143
 		}
 	st_case_143:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 46:
-			goto st136
-		case 69:
-			goto st139
-		case 93:
-			goto tr95
-		case 101:
-			goto st139
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st144
-			}
-		case data[p] >= 9:
-			goto st88
+		if data[p] == 108 {
+			goto st144
 		}
 		goto tr88
 	st144:
@@ -4064,48 +3941,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		case 44:
 			goto st89
-		case 46:
-			goto st136
-		case 69:
-			goto st139
-		case 93:
-			goto tr95
-		case 101:
-			goto st139
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st144
-			}
-		case data[p] >= 9:
-			goto st88
-		}
-		goto tr88
-	tr94:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 145
-				top++
-				goto st83
-			}
-		}
-		goto st145
-	st145:
-		if p++; p == pe {
-			goto _test_eof145
-		}
-	st_case_145:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
 		case 93:
 			goto tr95
 		}
@@ -4113,12 +3948,21 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		}
 		goto tr88
+	st145:
+		if p++; p == pe {
+			goto _test_eof145
+		}
+	st_case_145:
+		if data[p] == 114 {
+			goto st146
+		}
+		goto tr88
 	st146:
 		if p++; p == pe {
 			goto _test_eof146
 		}
 	st_case_146:
-		if data[p] == 97 {
+		if data[p] == 117 {
 			goto st147
 		}
 		goto tr88
@@ -4127,7 +3971,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof147
 		}
 	st_case_147:
-		if data[p] == 108 {
+		if data[p] == 101 {
 			goto st148
 		}
 		goto tr88
@@ -4136,116 +3980,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto _test_eof148
 		}
 	st_case_148:
-		if data[p] == 115 {
-			goto st149
-		}
-		goto tr88
-	st149:
-		if p++; p == pe {
-			goto _test_eof149
-		}
-	st_case_149:
-		if data[p] == 101 {
-			goto st150
-		}
-		goto tr88
-	st150:
-		if p++; p == pe {
-			goto _test_eof150
-		}
-	st_case_150:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st88
-		}
-		goto tr88
-	st151:
-		if p++; p == pe {
-			goto _test_eof151
-		}
-	st_case_151:
-		if data[p] == 117 {
-			goto st152
-		}
-		goto tr88
-	st152:
-		if p++; p == pe {
-			goto _test_eof152
-		}
-	st_case_152:
-		if data[p] == 108 {
-			goto st153
-		}
-		goto tr88
-	st153:
-		if p++; p == pe {
-			goto _test_eof153
-		}
-	st_case_153:
-		if data[p] == 108 {
-			goto st154
-		}
-		goto tr88
-	st154:
-		if p++; p == pe {
-			goto _test_eof154
-		}
-	st_case_154:
-		switch data[p] {
-		case 13:
-			goto st88
-		case 32:
-			goto st88
-		case 44:
-			goto st89
-		case 93:
-			goto tr95
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st88
-		}
-		goto tr88
-	st155:
-		if p++; p == pe {
-			goto _test_eof155
-		}
-	st_case_155:
-		if data[p] == 114 {
-			goto st156
-		}
-		goto tr88
-	st156:
-		if p++; p == pe {
-			goto _test_eof156
-		}
-	st_case_156:
-		if data[p] == 117 {
-			goto st157
-		}
-		goto tr88
-	st157:
-		if p++; p == pe {
-			goto _test_eof157
-		}
-	st_case_157:
-		if data[p] == 101 {
-			goto st158
-		}
-		goto tr88
-	st158:
-		if p++; p == pe {
-			goto _test_eof158
-		}
-	st_case_158:
 		switch data[p] {
 		case 13:
 			goto st88
@@ -4266,17 +4000,17 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 159
+				stack[top] = 149
 				top++
-				goto st160
+				goto st150
 			}
 		}
-		goto st159
-	st159:
+		goto st149
+	st149:
 		if p++; p == pe {
-			goto _test_eof159
+			goto _test_eof149
 		}
-	st_case_159:
+	st_case_149:
 		switch data[p] {
 		case 13:
 			goto st88
@@ -4291,6 +4025,210 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st88
 		}
 		goto tr88
+	st150:
+		if p++; p == pe {
+			goto _test_eof150
+		}
+	st_case_150:
+		switch data[p] {
+		case 13:
+			goto st151
+		case 32:
+			goto st151
+		case 34:
+			goto st152
+		case 125:
+			goto tr159
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st151
+		}
+		goto tr156
+	st151:
+		if p++; p == pe {
+			goto _test_eof151
+		}
+	st_case_151:
+		switch data[p] {
+		case 13:
+			goto st151
+		case 32:
+			goto st151
+		case 34:
+			goto st152
+		case 125:
+			goto tr159
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st151
+		}
+		goto tr156
+	st152:
+		if p++; p == pe {
+			goto _test_eof152
+		}
+	st_case_152:
+		switch data[p] {
+		case 34:
+			goto st154
+		case 92:
+			goto st236
+		}
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st153
+	st153:
+		if p++; p == pe {
+			goto _test_eof153
+		}
+	st_case_153:
+		switch data[p] {
+		case 34:
+			goto st154
+		case 92:
+			goto st236
+		}
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st153
+	st154:
+		if p++; p == pe {
+			goto _test_eof154
+		}
+	st_case_154:
+		switch data[p] {
+		case 13:
+			goto st155
+		case 32:
+			goto st155
+		case 58:
+			goto st156
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st155
+		}
+		goto tr156
+	st155:
+		if p++; p == pe {
+			goto _test_eof155
+		}
+	st_case_155:
+		switch data[p] {
+		case 13:
+			goto st155
+		case 32:
+			goto st155
+		case 58:
+			goto st156
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st155
+		}
+		goto tr156
+	st156:
+		if p++; p == pe {
+			goto _test_eof156
+		}
+	st_case_156:
+		switch data[p] {
+		case 13:
+			goto st157
+		case 32:
+			goto st157
+		case 34:
+			goto st158
+		case 45:
+			goto st215
+		case 48:
+			goto st216
+		case 91:
+			goto tr170
+		case 102:
+			goto st222
+		case 110:
+			goto st227
+		case 116:
+			goto st231
+		case 123:
+			goto tr174
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st219
+			}
+		case data[p] >= 9:
+			goto st157
+		}
+		goto tr156
+	st157:
+		if p++; p == pe {
+			goto _test_eof157
+		}
+	st_case_157:
+		switch data[p] {
+		case 13:
+			goto st157
+		case 32:
+			goto st157
+		case 34:
+			goto st158
+		case 45:
+			goto st215
+		case 48:
+			goto st216
+		case 91:
+			goto tr170
+		case 102:
+			goto st222
+		case 110:
+			goto st227
+		case 116:
+			goto st231
+		case 123:
+			goto tr174
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st219
+			}
+		case data[p] >= 9:
+			goto st157
+		}
+		goto tr156
+	st158:
+		if p++; p == pe {
+			goto _test_eof158
+		}
+	st_case_158:
+		switch data[p] {
+		case 34:
+			goto st160
+		case 92:
+			goto st208
+		}
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st159
+	st159:
+		if p++; p == pe {
+			goto _test_eof159
+		}
+	st_case_159:
+		switch data[p] {
+		case 34:
+			goto st160
+		case 92:
+			goto st208
+		}
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st159
 	st160:
 		if p++; p == pe {
 			goto _test_eof160
@@ -4301,15 +4239,15 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st161
 		case 32:
 			goto st161
-		case 34:
+		case 44:
 			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st161
 		}
-		goto tr166
+		goto tr156
 	st161:
 		if p++; p == pe {
 			goto _test_eof161
@@ -4320,79 +4258,79 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st161
 		case 32:
 			goto st161
-		case 34:
+		case 44:
 			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st161
 		}
-		goto tr166
+		goto tr156
 	st162:
 		if p++; p == pe {
 			goto _test_eof162
 		}
 	st_case_162:
 		switch data[p] {
+		case 13:
+			goto st163
+		case 32:
+			goto st163
 		case 34:
 			goto st164
-		case 92:
-			goto st256
 		}
-		if data[p] <= 31 {
-			goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st163
 		}
-		goto st163
+		goto tr156
 	st163:
 		if p++; p == pe {
 			goto _test_eof163
 		}
 	st_case_163:
 		switch data[p] {
+		case 13:
+			goto st163
+		case 32:
+			goto st163
 		case 34:
 			goto st164
-		case 92:
-			goto st256
 		}
-		if data[p] <= 31 {
-			goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st163
 		}
-		goto st163
+		goto tr156
 	st164:
 		if p++; p == pe {
 			goto _test_eof164
 		}
 	st_case_164:
 		switch data[p] {
-		case 13:
-			goto st165
-		case 32:
-			goto st165
-		case 58:
+		case 34:
 			goto st166
+		case 92:
+			goto st201
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st165
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st165
 	st165:
 		if p++; p == pe {
 			goto _test_eof165
 		}
 	st_case_165:
 		switch data[p] {
-		case 13:
-			goto st165
-		case 32:
-			goto st165
-		case 58:
+		case 34:
 			goto st166
+		case 92:
+			goto st201
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st165
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st165
 	st166:
 		if p++; p == pe {
 			goto _test_eof166
@@ -4403,32 +4341,13 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st167
 		case 32:
 			goto st167
-		case 34:
+		case 58:
 			goto st168
-		case 45:
-			goto st230
-		case 48:
-			goto st231
-		case 91:
-			goto tr180
-		case 102:
-			goto st242
-		case 110:
-			goto st247
-		case 116:
-			goto st251
-		case 123:
-			goto tr184
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st239
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st167
 		}
-		goto tr166
+		goto tr156
 	st167:
 		if p++; p == pe {
 			goto _test_eof167
@@ -4439,100 +4358,115 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 			goto st167
 		case 32:
 			goto st167
-		case 34:
+		case 58:
 			goto st168
-		case 45:
-			goto st230
-		case 48:
-			goto st231
-		case 91:
-			goto tr180
-		case 102:
-			goto st242
-		case 110:
-			goto st247
-		case 116:
-			goto st251
-		case 123:
-			goto tr184
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st239
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st167
 		}
-		goto tr166
+		goto tr156
 	st168:
 		if p++; p == pe {
 			goto _test_eof168
 		}
 	st_case_168:
 		switch data[p] {
+		case 13:
+			goto st169
+		case 32:
+			goto st169
 		case 34:
 			goto st170
-		case 92:
-			goto st223
+		case 45:
+			goto st180
+		case 48:
+			goto st181
+		case 91:
+			goto tr192
+		case 102:
+			goto st187
+		case 110:
+			goto st192
+		case 116:
+			goto st196
+		case 123:
+			goto tr196
 		}
-		if data[p] <= 31 {
-			goto tr166
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st184
+			}
+		case data[p] >= 9:
+			goto st169
 		}
-		goto st169
+		goto tr156
 	st169:
 		if p++; p == pe {
 			goto _test_eof169
 		}
 	st_case_169:
 		switch data[p] {
+		case 13:
+			goto st169
+		case 32:
+			goto st169
 		case 34:
 			goto st170
-		case 92:
-			goto st223
+		case 45:
+			goto st180
+		case 48:
+			goto st181
+		case 91:
+			goto tr192
+		case 102:
+			goto st187
+		case 110:
+			goto st192
+		case 116:
+			goto st196
+		case 123:
+			goto tr196
 		}
-		if data[p] <= 31 {
-			goto tr166
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st184
+			}
+		case data[p] >= 9:
+			goto st169
 		}
-		goto st169
+		goto tr156
 	st170:
 		if p++; p == pe {
 			goto _test_eof170
 		}
 	st_case_170:
 		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
+		case 34:
 			goto st172
-		case 125:
-			goto tr169
+		case 92:
+			goto st173
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st171
 	st171:
 		if p++; p == pe {
 			goto _test_eof171
 		}
 	st_case_171:
 		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
+		case 34:
 			goto st172
-		case 125:
-			goto tr169
+		case 92:
+			goto st173
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st171
 	st172:
 		if p++; p == pe {
 			goto _test_eof172
@@ -4540,33 +4474,57 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_172:
 		switch data[p] {
 		case 13:
-			goto st173
+			goto st161
 		case 32:
-			goto st173
-		case 34:
-			goto st174
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st173
+			goto st161
 		}
-		goto tr166
+		goto tr156
+	tr159:
+		{
+			top--
+			cs = stack[top]
+			goto _again
+		}
+		goto st246
+	st246:
+		if p++; p == pe {
+			goto _test_eof246
+		}
+	st_case_246:
+		goto st0
 	st173:
 		if p++; p == pe {
 			goto _test_eof173
 		}
 	st_case_173:
 		switch data[p] {
-		case 13:
-			goto st173
-		case 32:
-			goto st173
 		case 34:
 			goto st174
+		case 47:
+			goto st174
+		case 92:
+			goto st174
+		case 98:
+			goto st174
+		case 102:
+			goto st174
+		case 110:
+			goto st174
+		case 114:
+			goto st174
+		case 116:
+			goto st174
+		case 117:
+			goto st175
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st173
-		}
-		goto tr166
+		goto tr156
 	st174:
 		if p++; p == pe {
 			goto _test_eof174
@@ -4574,165 +4532,141 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_174:
 		switch data[p] {
 		case 34:
-			goto st176
+			goto st172
 		case 92:
-			goto st216
+			goto st173
 		}
 		if data[p] <= 31 {
-			goto tr166
+			goto tr156
 		}
-		goto st175
+		goto st171
 	st175:
 		if p++; p == pe {
 			goto _test_eof175
 		}
 	st_case_175:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st176
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st176
+			}
+		default:
 			goto st176
-		case 92:
-			goto st216
 		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st175
+		goto tr156
 	st176:
 		if p++; p == pe {
 			goto _test_eof176
 		}
 	st_case_176:
-		switch data[p] {
-		case 13:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st177
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st177
+			}
+		default:
 			goto st177
-		case 32:
-			goto st177
-		case 58:
-			goto st178
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st177
-		}
-		goto tr166
+		goto tr156
 	st177:
 		if p++; p == pe {
 			goto _test_eof177
 		}
 	st_case_177:
-		switch data[p] {
-		case 13:
-			goto st177
-		case 32:
-			goto st177
-		case 58:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st178
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st178
+			}
+		default:
 			goto st178
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st177
-		}
-		goto tr166
+		goto tr156
 	st178:
 		if p++; p == pe {
 			goto _test_eof178
 		}
 	st_case_178:
-		switch data[p] {
-		case 13:
-			goto st179
-		case 32:
-			goto st179
-		case 34:
-			goto st180
-		case 45:
-			goto st190
-		case 48:
-			goto st191
-		case 91:
-			goto tr202
-		case 102:
-			goto st202
-		case 110:
-			goto st207
-		case 116:
-			goto st211
-		case 123:
-			goto tr206
-		}
 		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st199
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st179
 			}
-		case data[p] >= 9:
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st179
+			}
+		default:
 			goto st179
 		}
-		goto tr166
+		goto tr156
 	st179:
 		if p++; p == pe {
 			goto _test_eof179
 		}
 	st_case_179:
 		switch data[p] {
-		case 13:
-			goto st179
-		case 32:
-			goto st179
 		case 34:
-			goto st180
-		case 45:
-			goto st190
-		case 48:
-			goto st191
-		case 91:
-			goto tr202
-		case 102:
-			goto st202
-		case 110:
-			goto st207
-		case 116:
-			goto st211
-		case 123:
-			goto tr206
+			goto st172
+		case 92:
+			goto st173
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st199
-			}
-		case data[p] >= 9:
-			goto st179
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st171
 	st180:
 		if p++; p == pe {
 			goto _test_eof180
 		}
 	st_case_180:
-		switch data[p] {
-		case 34:
-			goto st182
-		case 92:
-			goto st183
+		if data[p] == 48 {
+			goto st181
 		}
-		if data[p] <= 31 {
-			goto tr166
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st184
 		}
-		goto st181
+		goto tr156
 	st181:
 		if p++; p == pe {
 			goto _test_eof181
 		}
 	st_case_181:
 		switch data[p] {
-		case 34:
-			goto st182
-		case 92:
-			goto st183
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr206
+		case 69:
+			goto tr207
+		case 101:
+			goto tr207
+		case 125:
+			goto tr159
 		}
-		if data[p] <= 31 {
-			goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto st181
+		goto tr156
+	tr206:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st182
 	st182:
 		if p++; p == pe {
 			goto _test_eof182
@@ -4740,171 +4674,167 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_182:
 		switch data[p] {
 		case 13:
-			goto st171
+			goto st161
 		case 32:
-			goto st171
+			goto st161
 		case 44:
-			goto st172
+			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+			goto st161
 		}
-		goto tr166
-	tr169:
-		{
-			top--
-			cs = stack[top]
-			goto _again
-		}
-		goto st266
-	st266:
-		if p++; p == pe {
-			goto _test_eof266
-		}
-	st_case_266:
-		goto st0
+		goto tr156
+	tr207:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st183
 	st183:
 		if p++; p == pe {
 			goto _test_eof183
 		}
 	st_case_183:
 		switch data[p] {
-		case 34:
-			goto st184
-		case 47:
-			goto st184
-		case 92:
-			goto st184
-		case 98:
-			goto st184
-		case 102:
-			goto st184
-		case 110:
-			goto st184
-		case 114:
-			goto st184
-		case 116:
-			goto st184
-		case 117:
-			goto st185
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
 	st184:
 		if p++; p == pe {
 			goto _test_eof184
 		}
 	st_case_184:
 		switch data[p] {
-		case 34:
-			goto st182
-		case 92:
-			goto st183
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr206
+		case 69:
+			goto tr207
+		case 101:
+			goto tr207
+		case 125:
+			goto tr159
 		}
-		if data[p] <= 31 {
-			goto tr166
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st185
+			}
+		case data[p] >= 9:
+			goto st161
 		}
-		goto st181
+		goto tr156
 	st185:
 		if p++; p == pe {
 			goto _test_eof185
 		}
 	st_case_185:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st186
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st186
-			}
-		default:
-			goto st186
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr206
+		case 69:
+			goto tr207
+		case 101:
+			goto tr207
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st185
+			}
+		case data[p] >= 9:
+			goto st161
+		}
+		goto tr156
+	tr192:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 186
+				top++
+				goto st83
+			}
+		}
+		goto st186
 	st186:
 		if p++; p == pe {
 			goto _test_eof186
 		}
 	st_case_186:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st187
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st187
-			}
-		default:
-			goto st187
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
 	st187:
 		if p++; p == pe {
 			goto _test_eof187
 		}
 	st_case_187:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st188
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st188
-			}
-		default:
+		if data[p] == 97 {
 			goto st188
 		}
-		goto tr166
+		goto tr156
 	st188:
 		if p++; p == pe {
 			goto _test_eof188
 		}
 	st_case_188:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st189
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st189
-			}
-		default:
+		if data[p] == 108 {
 			goto st189
 		}
-		goto tr166
+		goto tr156
 	st189:
 		if p++; p == pe {
 			goto _test_eof189
 		}
 	st_case_189:
-		switch data[p] {
-		case 34:
-			goto st182
-		case 92:
-			goto st183
+		if data[p] == 115 {
+			goto st190
 		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st181
+		goto tr156
 	st190:
 		if p++; p == pe {
 			goto _test_eof190
 		}
 	st_case_190:
-		if data[p] == 48 {
+		if data[p] == 101 {
 			goto st191
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st199
-		}
-		goto tr166
+		goto tr156
 	st191:
 		if p++; p == pe {
 			goto _test_eof191
@@ -4912,161 +4842,91 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_191:
 		switch data[p] {
 		case 13:
-			goto st171
+			goto st161
 		case 32:
-			goto st171
+			goto st161
 		case 44:
-			goto st172
-		case 46:
-			goto st192
-		case 69:
-			goto st195
-		case 101:
-			goto st195
+			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+			goto st161
 		}
-		goto tr166
+		goto tr156
 	st192:
 		if p++; p == pe {
 			goto _test_eof192
 		}
 	st_case_192:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 117 {
 			goto st193
 		}
-		goto tr166
+		goto tr156
 	st193:
 		if p++; p == pe {
 			goto _test_eof193
 		}
 	st_case_193:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 69:
-			goto st195
-		case 101:
-			goto st195
-		case 125:
-			goto tr169
+		if data[p] == 108 {
+			goto st194
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st194
-			}
-		case data[p] >= 9:
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st194:
 		if p++; p == pe {
 			goto _test_eof194
 		}
 	st_case_194:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 69:
+		if data[p] == 108 {
 			goto st195
-		case 101:
-			goto st195
-		case 125:
-			goto tr169
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st194
-			}
-		case data[p] >= 9:
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st195:
 		if p++; p == pe {
 			goto _test_eof195
 		}
 	st_case_195:
 		switch data[p] {
-		case 43:
-			goto st196
-		case 45:
-			goto st196
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st197
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto tr166
+		goto tr156
 	st196:
 		if p++; p == pe {
 			goto _test_eof196
 		}
 	st_case_196:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 114 {
 			goto st197
 		}
-		goto tr166
+		goto tr156
 	st197:
 		if p++; p == pe {
 			goto _test_eof197
 		}
 	st_case_197:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		if data[p] == 117 {
+			goto st198
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st198
-			}
-		case data[p] >= 9:
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st198:
 		if p++; p == pe {
 			goto _test_eof198
 		}
 	st_case_198:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		if data[p] == 101 {
+			goto st199
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st198
-			}
-		case data[p] >= 9:
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st199:
 		if p++; p == pe {
 			goto _test_eof199
@@ -5074,29 +4934,30 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_199:
 		switch data[p] {
 		case 13:
-			goto st171
+			goto st161
 		case 32:
-			goto st171
+			goto st161
 		case 44:
-			goto st172
-		case 46:
-			goto st192
-		case 69:
-			goto st195
-		case 101:
-			goto st195
+			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st200
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
+	tr196:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
-		case data[p] >= 9:
-			goto st171
+			{
+				stack[top] = 200
+				top++
+				goto st150
+			}
 		}
-		goto tr166
+		goto st200
 	st200:
 		if p++; p == pe {
 			goto _test_eof200
@@ -5104,568 +4965,574 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_200:
 		switch data[p] {
 		case 13:
-			goto st171
+			goto st161
 		case 32:
-			goto st171
+			goto st161
 		case 44:
-			goto st172
-		case 46:
-			goto st192
-		case 69:
-			goto st195
-		case 101:
-			goto st195
+			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st200
-			}
-		case data[p] >= 9:
-			goto st171
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto tr166
-	tr202:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 201
-				top++
-				goto st83
-			}
-		}
-		goto st201
+		goto tr156
 	st201:
 		if p++; p == pe {
 			goto _test_eof201
 		}
 	st_case_201:
 		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		case 34:
+			goto st202
+		case 47:
+			goto st202
+		case 92:
+			goto st202
+		case 98:
+			goto st202
+		case 102:
+			goto st202
+		case 110:
+			goto st202
+		case 114:
+			goto st202
+		case 116:
+			goto st202
+		case 117:
+			goto st203
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st202:
 		if p++; p == pe {
 			goto _test_eof202
 		}
 	st_case_202:
-		if data[p] == 97 {
-			goto st203
+		switch data[p] {
+		case 34:
+			goto st166
+		case 92:
+			goto st201
 		}
-		goto tr166
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st165
 	st203:
 		if p++; p == pe {
 			goto _test_eof203
 		}
 	st_case_203:
-		if data[p] == 108 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st204
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st204
+			}
+		default:
 			goto st204
 		}
-		goto tr166
+		goto tr156
 	st204:
 		if p++; p == pe {
 			goto _test_eof204
 		}
 	st_case_204:
-		if data[p] == 115 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st205
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st205
+			}
+		default:
 			goto st205
 		}
-		goto tr166
+		goto tr156
 	st205:
 		if p++; p == pe {
 			goto _test_eof205
 		}
 	st_case_205:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st206
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st206
+			}
+		default:
 			goto st206
 		}
-		goto tr166
+		goto tr156
 	st206:
 		if p++; p == pe {
 			goto _test_eof206
 		}
 	st_case_206:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st207
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st207
+			}
+		default:
+			goto st207
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st207:
 		if p++; p == pe {
 			goto _test_eof207
 		}
 	st_case_207:
-		if data[p] == 117 {
-			goto st208
+		switch data[p] {
+		case 34:
+			goto st166
+		case 92:
+			goto st201
 		}
-		goto tr166
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st165
 	st208:
 		if p++; p == pe {
 			goto _test_eof208
 		}
 	st_case_208:
-		if data[p] == 108 {
+		switch data[p] {
+		case 34:
 			goto st209
+		case 47:
+			goto st209
+		case 92:
+			goto st209
+		case 98:
+			goto st209
+		case 102:
+			goto st209
+		case 110:
+			goto st209
+		case 114:
+			goto st209
+		case 116:
+			goto st209
+		case 117:
+			goto st210
 		}
-		goto tr166
+		goto tr156
 	st209:
 		if p++; p == pe {
 			goto _test_eof209
 		}
 	st_case_209:
-		if data[p] == 108 {
-			goto st210
+		switch data[p] {
+		case 34:
+			goto st160
+		case 92:
+			goto st208
 		}
-		goto tr166
+		if data[p] <= 31 {
+			goto tr156
+		}
+		goto st159
 	st210:
 		if p++; p == pe {
 			goto _test_eof210
 		}
 	st_case_210:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st211
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st211
+			}
+		default:
+			goto st211
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st211:
 		if p++; p == pe {
 			goto _test_eof211
 		}
 	st_case_211:
-		if data[p] == 114 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st212
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st212
+			}
+		default:
 			goto st212
 		}
-		goto tr166
+		goto tr156
 	st212:
 		if p++; p == pe {
 			goto _test_eof212
 		}
 	st_case_212:
-		if data[p] == 117 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st213
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st213
+			}
+		default:
 			goto st213
 		}
-		goto tr166
+		goto tr156
 	st213:
 		if p++; p == pe {
 			goto _test_eof213
 		}
 	st_case_213:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st214
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st214
+			}
+		default:
 			goto st214
 		}
-		goto tr166
+		goto tr156
 	st214:
 		if p++; p == pe {
 			goto _test_eof214
 		}
 	st_case_214:
 		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		case 34:
+			goto st160
+		case 92:
+			goto st208
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
-	tr206:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 215
-				top++
-				goto st160
-			}
-		}
-		goto st215
+		goto st159
 	st215:
 		if p++; p == pe {
 			goto _test_eof215
 		}
 	st_case_215:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		if data[p] == 48 {
+			goto st216
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st219
 		}
-		goto tr166
+		goto tr156
 	st216:
 		if p++; p == pe {
 			goto _test_eof216
 		}
 	st_case_216:
 		switch data[p] {
-		case 34:
-			goto st217
-		case 47:
-			goto st217
-		case 92:
-			goto st217
-		case 98:
-			goto st217
-		case 102:
-			goto st217
-		case 110:
-			goto st217
-		case 114:
-			goto st217
-		case 116:
-			goto st217
-		case 117:
-			goto st218
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr231
+		case 69:
+			goto tr232
+		case 101:
+			goto tr232
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
+	tr231:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st217
 	st217:
 		if p++; p == pe {
 			goto _test_eof217
 		}
 	st_case_217:
 		switch data[p] {
-		case 34:
-			goto st176
-		case 92:
-			goto st216
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		if data[p] <= 31 {
-			goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto st175
+		goto tr156
+	tr232:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st218
 	st218:
 		if p++; p == pe {
 			goto _test_eof218
 		}
 	st_case_218:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st219
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st219
-			}
-		default:
-			goto st219
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
 	st219:
 		if p++; p == pe {
 			goto _test_eof219
 		}
 	st_case_219:
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr231
+		case 69:
+			goto tr232
+		case 101:
+			goto tr232
+		case 125:
+			goto tr159
+		}
 		switch {
-		case data[p] < 65:
+		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st220
 			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st220
-			}
-		default:
-			goto st220
+		case data[p] >= 9:
+			goto st161
 		}
-		goto tr166
+		goto tr156
 	st220:
 		if p++; p == pe {
 			goto _test_eof220
 		}
 	st_case_220:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st221
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st221
-			}
-		default:
-			goto st221
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 46:
+			goto tr231
+		case 69:
+			goto tr232
+		case 101:
+			goto tr232
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st220
+			}
+		case data[p] >= 9:
+			goto st161
+		}
+		goto tr156
+	tr170:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 221
+				top++
+				goto st83
+			}
+		}
+		goto st221
 	st221:
 		if p++; p == pe {
 			goto _test_eof221
 		}
 	st_case_221:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st222
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st222
-			}
-		default:
-			goto st222
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
 	st222:
 		if p++; p == pe {
 			goto _test_eof222
 		}
 	st_case_222:
-		switch data[p] {
-		case 34:
-			goto st176
-		case 92:
-			goto st216
+		if data[p] == 97 {
+			goto st223
 		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st175
+		goto tr156
 	st223:
 		if p++; p == pe {
 			goto _test_eof223
 		}
 	st_case_223:
-		switch data[p] {
-		case 34:
+		if data[p] == 108 {
 			goto st224
-		case 47:
-			goto st224
-		case 92:
-			goto st224
-		case 98:
-			goto st224
-		case 102:
-			goto st224
-		case 110:
-			goto st224
-		case 114:
-			goto st224
-		case 116:
-			goto st224
-		case 117:
-			goto st225
 		}
-		goto tr166
+		goto tr156
 	st224:
 		if p++; p == pe {
 			goto _test_eof224
 		}
 	st_case_224:
-		switch data[p] {
-		case 34:
-			goto st170
-		case 92:
-			goto st223
+		if data[p] == 115 {
+			goto st225
 		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st169
+		goto tr156
 	st225:
 		if p++; p == pe {
 			goto _test_eof225
 		}
 	st_case_225:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st226
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st226
-			}
-		default:
+		if data[p] == 101 {
 			goto st226
 		}
-		goto tr166
+		goto tr156
 	st226:
 		if p++; p == pe {
 			goto _test_eof226
 		}
 	st_case_226:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st227
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st227
-			}
-		default:
-			goto st227
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		goto tr166
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
 	st227:
 		if p++; p == pe {
 			goto _test_eof227
 		}
 	st_case_227:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st228
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st228
-			}
-		default:
+		if data[p] == 117 {
 			goto st228
 		}
-		goto tr166
+		goto tr156
 	st228:
 		if p++; p == pe {
 			goto _test_eof228
 		}
 	st_case_228:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st229
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st229
-			}
-		default:
+		if data[p] == 108 {
 			goto st229
 		}
-		goto tr166
+		goto tr156
 	st229:
 		if p++; p == pe {
 			goto _test_eof229
 		}
 	st_case_229:
-		switch data[p] {
-		case 34:
-			goto st170
-		case 92:
-			goto st223
+		if data[p] == 108 {
+			goto st230
 		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st169
+		goto tr156
 	st230:
 		if p++; p == pe {
 			goto _test_eof230
 		}
 	st_case_230:
-		if data[p] == 48 {
-			goto st231
+		switch data[p] {
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st239
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto tr166
+		goto tr156
 	st231:
 		if p++; p == pe {
 			goto _test_eof231
 		}
 	st_case_231:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 46:
+		if data[p] == 114 {
 			goto st232
-		case 69:
-			goto st235
-		case 101:
-			goto st235
-		case 125:
-			goto tr169
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st232:
 		if p++; p == pe {
 			goto _test_eof232
 		}
 	st_case_232:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 117 {
 			goto st233
 		}
-		goto tr166
+		goto tr156
 	st233:
 		if p++; p == pe {
 			goto _test_eof233
 		}
 	st_case_233:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 69:
-			goto st235
-		case 101:
-			goto st235
-		case 125:
-			goto tr169
+		if data[p] == 101 {
+			goto st234
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st234
-			}
-		case data[p] >= 9:
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st234:
 		if p++; p == pe {
 			goto _test_eof234
@@ -5673,496 +5540,177 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	st_case_234:
 		switch data[p] {
 		case 13:
-			goto st171
+			goto st161
 		case 32:
-			goto st171
+			goto st161
 		case 44:
-			goto st172
-		case 69:
-			goto st235
-		case 101:
-			goto st235
+			goto st162
 		case 125:
-			goto tr169
+			goto tr159
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st234
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
+		}
+		goto tr156
+	tr174:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
-		case data[p] >= 9:
-			goto st171
+			{
+				stack[top] = 235
+				top++
+				goto st150
+			}
 		}
-		goto tr166
+		goto st235
 	st235:
 		if p++; p == pe {
 			goto _test_eof235
 		}
 	st_case_235:
 		switch data[p] {
-		case 43:
-			goto st236
-		case 45:
-			goto st236
+		case 13:
+			goto st161
+		case 32:
+			goto st161
+		case 44:
+			goto st162
+		case 125:
+			goto tr159
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st237
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st161
 		}
-		goto tr166
+		goto tr156
 	st236:
 		if p++; p == pe {
 			goto _test_eof236
 		}
 	st_case_236:
-		if 48 <= data[p] && data[p] <= 57 {
+		switch data[p] {
+		case 34:
 			goto st237
+		case 47:
+			goto st237
+		case 92:
+			goto st237
+		case 98:
+			goto st237
+		case 102:
+			goto st237
+		case 110:
+			goto st237
+		case 114:
+			goto st237
+		case 116:
+			goto st237
+		case 117:
+			goto st238
 		}
-		goto tr166
+		goto tr156
 	st237:
 		if p++; p == pe {
 			goto _test_eof237
 		}
 	st_case_237:
 		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		case 34:
+			goto st154
+		case 92:
+			goto st236
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st238
-			}
-		case data[p] >= 9:
-			goto st171
+		if data[p] <= 31 {
+			goto tr156
 		}
-		goto tr166
+		goto st153
 	st238:
 		if p++; p == pe {
 			goto _test_eof238
 		}
 	st_case_238:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st238
+				goto st239
 			}
-		case data[p] >= 9:
-			goto st171
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st239
+			}
+		default:
+			goto st239
 		}
-		goto tr166
+		goto tr156
 	st239:
 		if p++; p == pe {
 			goto _test_eof239
 		}
 	st_case_239:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 46:
-			goto st232
-		case 69:
-			goto st235
-		case 101:
-			goto st235
-		case 125:
-			goto tr169
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st240
 			}
-		case data[p] >= 9:
-			goto st171
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st240
+			}
+		default:
+			goto st240
 		}
-		goto tr166
+		goto tr156
 	st240:
 		if p++; p == pe {
 			goto _test_eof240
 		}
 	st_case_240:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 46:
-			goto st232
-		case 69:
-			goto st235
-		case 101:
-			goto st235
-		case 125:
-			goto tr169
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st240
+				goto st241
 			}
-		case data[p] >= 9:
-			goto st171
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st241
+			}
+		default:
+			goto st241
 		}
-		goto tr166
-	tr180:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 241
-				top++
-				goto st83
-			}
-		}
-		goto st241
+		goto tr156
 	st241:
 		if p++; p == pe {
 			goto _test_eof241
 		}
 	st_case_241:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st242
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st242
+			}
+		default:
+			goto st242
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
+		goto tr156
 	st242:
 		if p++; p == pe {
 			goto _test_eof242
 		}
 	st_case_242:
-		if data[p] == 97 {
-			goto st243
-		}
-		goto tr166
-	st243:
-		if p++; p == pe {
-			goto _test_eof243
-		}
-	st_case_243:
-		if data[p] == 108 {
-			goto st244
-		}
-		goto tr166
-	st244:
-		if p++; p == pe {
-			goto _test_eof244
-		}
-	st_case_244:
-		if data[p] == 115 {
-			goto st245
-		}
-		goto tr166
-	st245:
-		if p++; p == pe {
-			goto _test_eof245
-		}
-	st_case_245:
-		if data[p] == 101 {
-			goto st246
-		}
-		goto tr166
-	st246:
-		if p++; p == pe {
-			goto _test_eof246
-		}
-	st_case_246:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
-	st247:
-		if p++; p == pe {
-			goto _test_eof247
-		}
-	st_case_247:
-		if data[p] == 117 {
-			goto st248
-		}
-		goto tr166
-	st248:
-		if p++; p == pe {
-			goto _test_eof248
-		}
-	st_case_248:
-		if data[p] == 108 {
-			goto st249
-		}
-		goto tr166
-	st249:
-		if p++; p == pe {
-			goto _test_eof249
-		}
-	st_case_249:
-		if data[p] == 108 {
-			goto st250
-		}
-		goto tr166
-	st250:
-		if p++; p == pe {
-			goto _test_eof250
-		}
-	st_case_250:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
-	st251:
-		if p++; p == pe {
-			goto _test_eof251
-		}
-	st_case_251:
-		if data[p] == 114 {
-			goto st252
-		}
-		goto tr166
-	st252:
-		if p++; p == pe {
-			goto _test_eof252
-		}
-	st_case_252:
-		if data[p] == 117 {
-			goto st253
-		}
-		goto tr166
-	st253:
-		if p++; p == pe {
-			goto _test_eof253
-		}
-	st_case_253:
-		if data[p] == 101 {
-			goto st254
-		}
-		goto tr166
-	st254:
-		if p++; p == pe {
-			goto _test_eof254
-		}
-	st_case_254:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
-	tr184:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 255
-				top++
-				goto st160
-			}
-		}
-		goto st255
-	st255:
-		if p++; p == pe {
-			goto _test_eof255
-		}
-	st_case_255:
-		switch data[p] {
-		case 13:
-			goto st171
-		case 32:
-			goto st171
-		case 44:
-			goto st172
-		case 125:
-			goto tr169
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st171
-		}
-		goto tr166
-	st256:
-		if p++; p == pe {
-			goto _test_eof256
-		}
-	st_case_256:
 		switch data[p] {
 		case 34:
-			goto st257
-		case 47:
-			goto st257
+			goto st154
 		case 92:
-			goto st257
-		case 98:
-			goto st257
-		case 102:
-			goto st257
-		case 110:
-			goto st257
-		case 114:
-			goto st257
-		case 116:
-			goto st257
-		case 117:
-			goto st258
-		}
-		goto tr166
-	st257:
-		if p++; p == pe {
-			goto _test_eof257
-		}
-	st_case_257:
-		switch data[p] {
-		case 34:
-			goto st164
-		case 92:
-			goto st256
+			goto st236
 		}
 		if data[p] <= 31 {
-			goto tr166
+			goto tr156
 		}
-		goto st163
-	st258:
-		if p++; p == pe {
-			goto _test_eof258
-		}
-	st_case_258:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st259
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st259
-			}
-		default:
-			goto st259
-		}
-		goto tr166
-	st259:
-		if p++; p == pe {
-			goto _test_eof259
-		}
-	st_case_259:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st260
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st260
-			}
-		default:
-			goto st260
-		}
-		goto tr166
-	st260:
-		if p++; p == pe {
-			goto _test_eof260
-		}
-	st_case_260:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st261
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st261
-			}
-		default:
-			goto st261
-		}
-		goto tr166
-	st261:
-		if p++; p == pe {
-			goto _test_eof261
-		}
-	st_case_261:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st262
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st262
-			}
-		default:
-			goto st262
-		}
-		goto tr166
-	st262:
-		if p++; p == pe {
-			goto _test_eof262
-		}
-	st_case_262:
-		switch data[p] {
-		case 34:
-			goto st164
-		case 92:
-			goto st256
-		}
-		if data[p] <= 31 {
-			goto tr166
-		}
-		goto st163
+		goto st153
 	st_out:
 	_test_eof1:
 		cs = 1
@@ -6203,8 +5751,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	_test_eof13:
 		cs = 13
 		goto _test_eof
-	_test_eof263:
-		cs = 263
+	_test_eof243:
+		cs = 243
 		goto _test_eof
 	_test_eof14:
 		cs = 14
@@ -6413,8 +5961,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	_test_eof82:
 		cs = 82
 		goto _test_eof
-	_test_eof264:
-		cs = 264
+	_test_eof244:
+		cs = 244
 		goto _test_eof
 	_test_eof83:
 		cs = 83
@@ -6449,8 +5997,8 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	_test_eof93:
 		cs = 93
 		goto _test_eof
-	_test_eof265:
-		cs = 265
+	_test_eof245:
+		cs = 245
 		goto _test_eof
 	_test_eof94:
 		cs = 94
@@ -6689,6 +6237,9 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	_test_eof172:
 		cs = 172
 		goto _test_eof
+	_test_eof246:
+		cs = 246
+		goto _test_eof
 	_test_eof173:
 		cs = 173
 		goto _test_eof
@@ -6718,9 +6269,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 		goto _test_eof
 	_test_eof182:
 		cs = 182
-		goto _test_eof
-	_test_eof266:
-		cs = 266
 		goto _test_eof
 	_test_eof183:
 		cs = 183
@@ -6902,66 +6450,6 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 	_test_eof242:
 		cs = 242
 		goto _test_eof
-	_test_eof243:
-		cs = 243
-		goto _test_eof
-	_test_eof244:
-		cs = 244
-		goto _test_eof
-	_test_eof245:
-		cs = 245
-		goto _test_eof
-	_test_eof246:
-		cs = 246
-		goto _test_eof
-	_test_eof247:
-		cs = 247
-		goto _test_eof
-	_test_eof248:
-		cs = 248
-		goto _test_eof
-	_test_eof249:
-		cs = 249
-		goto _test_eof
-	_test_eof250:
-		cs = 250
-		goto _test_eof
-	_test_eof251:
-		cs = 251
-		goto _test_eof
-	_test_eof252:
-		cs = 252
-		goto _test_eof
-	_test_eof253:
-		cs = 253
-		goto _test_eof
-	_test_eof254:
-		cs = 254
-		goto _test_eof
-	_test_eof255:
-		cs = 255
-		goto _test_eof
-	_test_eof256:
-		cs = 256
-		goto _test_eof
-	_test_eof257:
-		cs = 257
-		goto _test_eof
-	_test_eof258:
-		cs = 258
-		goto _test_eof
-	_test_eof259:
-		cs = 259
-		goto _test_eof
-	_test_eof260:
-		cs = 260
-		goto _test_eof
-	_test_eof261:
-		cs = 261
-		goto _test_eof
-	_test_eof262:
-		cs = 262
-		goto _test_eof
 
 	_test_eof:
 		{
@@ -6972,7 +6460,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 
 				return p, stack, errInvalidArray
 
-			case 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159:
+			case 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149:
 				err = errUnexpectedEOF
 				{
 					p++
@@ -6985,7 +6473,7 @@ func handleArrayValues(data []byte, handler ArrayValueHandler, stack []int) (int
 					cs = 0
 					goto _out
 				}
-			case 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262:
+			case 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242:
 				err = errUnexpectedEOF
 				{
 					p++

--- a/common.rl
+++ b/common.rl
@@ -20,6 +20,4 @@ json_number = json_int ('.'[0-9]+)? ([eE][+\-]?[0-9]+)?;
 json_string = double_quote ( not_double_quote_or_escape | escaped_char )* double_quote;
 json_bool = json_true | json_false;
 
-json_simple_value = json_bool | json_null | json_string | json_number;
-
 }%%

--- a/object_handler_machine.rl.go
+++ b/object_handler_machine.rl.go
@@ -10,11 +10,11 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	var currentFieldStart, currentFieldEnd int
 
 	const handleObjectValues_start int = 1
-	const handleObjectValues_first_final int = 289
+	const handleObjectValues_first_final int = 269
 	const handleObjectValues_error int = 0
 
 	const handleObjectValues_en_skip_array int = 109
-	const handleObjectValues_en_skip_object int = 186
+	const handleObjectValues_en_skip_object int = 176
 	const handleObjectValues_en_main int = 1
 
 	{
@@ -42,8 +42,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st4
 		case 5:
 			goto st5
-		case 289:
-			goto st289
+		case 269:
+			goto st269
 		case 6:
 			goto st6
 		case 7:
@@ -90,8 +90,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st27
 		case 28:
 			goto st28
-		case 290:
-			goto st290
+		case 270:
+			goto st270
 		case 29:
 			goto st29
 		case 30:
@@ -274,8 +274,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st118
 		case 119:
 			goto st119
-		case 291:
-			goto st291
+		case 271:
+			goto st271
 		case 120:
 			goto st120
 		case 121:
@@ -434,6 +434,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st197
 		case 198:
 			goto st198
+		case 272:
+			goto st272
 		case 199:
 			goto st199
 		case 200:
@@ -454,8 +456,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st207
 		case 208:
 			goto st208
-		case 292:
-			goto st292
 		case 209:
 			goto st209
 		case 210:
@@ -576,46 +576,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st267
 		case 268:
 			goto st268
-		case 269:
-			goto st269
-		case 270:
-			goto st270
-		case 271:
-			goto st271
-		case 272:
-			goto st272
-		case 273:
-			goto st273
-		case 274:
-			goto st274
-		case 275:
-			goto st275
-		case 276:
-			goto st276
-		case 277:
-			goto st277
-		case 278:
-			goto st278
-		case 279:
-			goto st279
-		case 280:
-			goto st280
-		case 281:
-			goto st281
-		case 282:
-			goto st282
-		case 283:
-			goto st283
-		case 284:
-			goto st284
-		case 285:
-			goto st285
-		case 286:
-			goto st286
-		case 287:
-			goto st287
-		case 288:
-			goto st288
 		}
 
 		if p++; p == pe {
@@ -635,8 +595,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_4
 		case 5:
 			goto st_case_5
-		case 289:
-			goto st_case_289
+		case 269:
+			goto st_case_269
 		case 6:
 			goto st_case_6
 		case 7:
@@ -683,8 +643,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_27
 		case 28:
 			goto st_case_28
-		case 290:
-			goto st_case_290
+		case 270:
+			goto st_case_270
 		case 29:
 			goto st_case_29
 		case 30:
@@ -867,8 +827,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_118
 		case 119:
 			goto st_case_119
-		case 291:
-			goto st_case_291
+		case 271:
+			goto st_case_271
 		case 120:
 			goto st_case_120
 		case 121:
@@ -1027,6 +987,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_197
 		case 198:
 			goto st_case_198
+		case 272:
+			goto st_case_272
 		case 199:
 			goto st_case_199
 		case 200:
@@ -1047,8 +1009,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_207
 		case 208:
 			goto st_case_208
-		case 292:
-			goto st_case_292
 		case 209:
 			goto st_case_209
 		case 210:
@@ -1169,46 +1129,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st_case_267
 		case 268:
 			goto st_case_268
-		case 269:
-			goto st_case_269
-		case 270:
-			goto st_case_270
-		case 271:
-			goto st_case_271
-		case 272:
-			goto st_case_272
-		case 273:
-			goto st_case_273
-		case 274:
-			goto st_case_274
-		case 275:
-			goto st_case_275
-		case 276:
-			goto st_case_276
-		case 277:
-			goto st_case_277
-		case 278:
-			goto st_case_278
-		case 279:
-			goto st_case_279
-		case 280:
-			goto st_case_280
-		case 281:
-			goto st_case_281
-		case 282:
-			goto st_case_282
-		case 283:
-			goto st_case_283
-		case 284:
-			goto st_case_284
-		case 285:
-			goto st_case_285
-		case 286:
-			goto st_case_286
-		case 287:
-			goto st_case_287
-		case 288:
-			goto st_case_288
 		}
 		goto st_out
 	st1:
@@ -1243,7 +1163,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _out
 		}
 		goto st0
-	tr196:
+	tr186:
 		err = errInvalidObject
 		{
 			p++
@@ -1298,14 +1218,14 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		}
 	st_case_5:
 		if data[p] == 108 {
-			goto st289
+			goto st269
 		}
 		goto tr0
-	st289:
+	st269:
 		if p++; p == pe {
-			goto _test_eof289
+			goto _test_eof269
 		}
-	st_case_289:
+	st_case_269:
 		goto st0
 	st6:
 		if p++; p == pe {
@@ -1320,7 +1240,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto tr8
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st7
@@ -1339,7 +1259,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto tr8
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st7
@@ -1561,7 +1481,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -1580,7 +1500,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -1836,17 +1756,17 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
 		}
 		goto tr0
-	st290:
+	st270:
 		if p++; p == pe {
-			goto _test_eof290
+			goto _test_eof270
 		}
-	st_case_290:
+	st_case_270:
 		goto st0
 	st29:
 		if p++; p == pe {
@@ -2023,7 +1943,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st41
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2055,7 +1975,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st41
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2083,7 +2003,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st41
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2131,7 +2051,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2155,7 +2075,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2193,7 +2113,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st41
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2223,7 +2143,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st41
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2285,7 +2205,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2348,7 +2268,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2402,7 +2322,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2456,7 +2376,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2496,7 +2416,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			{
 				stack[top] = 61
 				top++
-				goto st186
+				goto st176
 			}
 		}
 		goto st61
@@ -2513,7 +2433,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2822,7 +2742,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st81
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -2854,7 +2774,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st81
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2882,7 +2802,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st81
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2930,7 +2850,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2954,7 +2874,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -2992,7 +2912,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st81
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -3022,7 +2942,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 101:
 			goto st81
 		case 125:
-			goto st290
+			goto st270
 		}
 		switch {
 		case data[p] > 10:
@@ -3084,7 +3004,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -3147,7 +3067,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -3201,7 +3121,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -3255,7 +3175,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -3295,7 +3215,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			{
 				stack[top] = 101
 				top++
-				goto st186
+				goto st176
 			}
 		}
 		goto st101
@@ -3312,7 +3232,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st18
 		case 125:
-			goto st290
+			goto st270
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st17
@@ -3459,26 +3379,26 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto st111
 		case 45:
-			goto st160
+			goto st155
 		case 48:
-			goto st161
+			goto st156
 		case 91:
 			goto tr124
 		case 93:
 			goto tr125
 		case 102:
-			goto st172
+			goto st162
 		case 110:
-			goto st177
+			goto st167
 		case 116:
-			goto st181
+			goto st171
 		case 123:
 			goto tr129
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st169
+				goto st159
 			}
 		case data[p] >= 9:
 			goto st110
@@ -3497,26 +3417,26 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto st111
 		case 45:
-			goto st160
+			goto st155
 		case 48:
-			goto st161
+			goto st156
 		case 91:
 			goto tr124
 		case 93:
 			goto tr125
 		case 102:
-			goto st172
+			goto st162
 		case 110:
-			goto st177
+			goto st167
 		case 116:
-			goto st181
+			goto st171
 		case 123:
 			goto tr129
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st169
+				goto st159
 			}
 		case data[p] >= 9:
 			goto st110
@@ -3531,7 +3451,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto st113
 		case 92:
-			goto st153
+			goto st148
 		}
 		if data[p] <= 31 {
 			goto tr118
@@ -3546,7 +3466,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto st113
 		case 92:
-			goto st153
+			goto st148
 		}
 		if data[p] <= 31 {
 			goto tr118
@@ -3609,18 +3529,18 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 91:
 			goto tr140
 		case 102:
-			goto st139
+			goto st134
 		case 110:
-			goto st144
+			goto st139
 		case 116:
-			goto st148
+			goto st143
 		case 123:
 			goto tr144
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st136
+				goto st131
 			}
 		case data[p] >= 9:
 			goto st116
@@ -3645,18 +3565,18 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 91:
 			goto tr140
 		case 102:
-			goto st139
+			goto st134
 		case 110:
-			goto st144
+			goto st139
 		case 116:
-			goto st148
+			goto st143
 		case 123:
 			goto tr144
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st136
+				goto st131
 			}
 		case data[p] >= 9:
 			goto st116
@@ -3717,12 +3637,12 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			cs = stack[top]
 			goto _again
 		}
-		goto st291
-	st291:
+		goto st271
+	st271:
 		if p++; p == pe {
-			goto _test_eof291
+			goto _test_eof271
 		}
-	st_case_291:
+	st_case_271:
 		goto st0
 	st120:
 		if p++; p == pe {
@@ -3861,7 +3781,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st128
 		}
 		if 49 <= data[p] && data[p] <= 57 {
-			goto st136
+			goto st131
 		}
 		goto tr118
 	st128:
@@ -3877,27 +3797,43 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st115
 		case 46:
-			goto st129
+			goto tr154
 		case 69:
-			goto st132
+			goto tr155
 		case 93:
 			goto tr125
 		case 101:
-			goto st132
+			goto tr155
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st114
 		}
 		goto tr118
+	tr154:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st129
 	st129:
 		if p++; p == pe {
 			goto _test_eof129
 		}
 	st_case_129:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st130
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
+	tr155:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st130
 	st130:
 		if p++; p == pe {
 			goto _test_eof130
@@ -3910,19 +3846,10 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		case 44:
 			goto st115
-		case 69:
-			goto st132
 		case 93:
 			goto tr125
-		case 101:
-			goto st132
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st131
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st114
 		}
 		goto tr118
@@ -3938,17 +3865,19 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		case 44:
 			goto st115
+		case 46:
+			goto tr154
 		case 69:
-			goto st132
+			goto tr155
 		case 93:
 			goto tr125
 		case 101:
-			goto st132
+			goto tr155
 		}
 		switch {
 		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st131
+				goto st132
 			}
 		case data[p] >= 9:
 			goto st114
@@ -3960,78 +3889,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		}
 	st_case_132:
 		switch data[p] {
-		case 43:
-			goto st133
-		case 45:
-			goto st133
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st134
-		}
-		goto tr118
-	st133:
-		if p++; p == pe {
-			goto _test_eof133
-		}
-	st_case_133:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st134
-		}
-		goto tr118
-	st134:
-		if p++; p == pe {
-			goto _test_eof134
-		}
-	st_case_134:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st135
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr118
-	st135:
-		if p++; p == pe {
-			goto _test_eof135
-		}
-	st_case_135:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st135
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr118
-	st136:
-		if p++; p == pe {
-			goto _test_eof136
-		}
-	st_case_136:
-		switch data[p] {
 		case 13:
 			goto st114
 		case 32:
@@ -4039,48 +3896,18 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 44:
 			goto st115
 		case 46:
-			goto st129
+			goto tr154
 		case 69:
-			goto st132
+			goto tr155
 		case 93:
 			goto tr125
 		case 101:
-			goto st132
+			goto tr155
 		}
 		switch {
 		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st137
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr118
-	st137:
-		if p++; p == pe {
-			goto _test_eof137
-		}
-	st_case_137:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st129
-		case 69:
-			goto st132
-		case 93:
-			goto tr125
-		case 101:
-			goto st132
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st137
+				goto st132
 			}
 		case data[p] >= 9:
 			goto st114
@@ -4092,12 +3919,67 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 138
+				stack[top] = 133
 				top++
 				goto st109
 			}
 		}
-		goto st138
+		goto st133
+	st133:
+		if p++; p == pe {
+			goto _test_eof133
+		}
+	st_case_133:
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
+		}
+		goto tr118
+	st134:
+		if p++; p == pe {
+			goto _test_eof134
+		}
+	st_case_134:
+		if data[p] == 97 {
+			goto st135
+		}
+		goto tr118
+	st135:
+		if p++; p == pe {
+			goto _test_eof135
+		}
+	st_case_135:
+		if data[p] == 108 {
+			goto st136
+		}
+		goto tr118
+	st136:
+		if p++; p == pe {
+			goto _test_eof136
+		}
+	st_case_136:
+		if data[p] == 115 {
+			goto st137
+		}
+		goto tr118
+	st137:
+		if p++; p == pe {
+			goto _test_eof137
+		}
+	st_case_137:
+		if data[p] == 101 {
+			goto st138
+		}
+		goto tr118
 	st138:
 		if p++; p == pe {
 			goto _test_eof138
@@ -4122,7 +4004,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof139
 		}
 	st_case_139:
-		if data[p] == 97 {
+		if data[p] == 117 {
 			goto st140
 		}
 		goto tr118
@@ -4140,7 +4022,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof141
 		}
 	st_case_141:
-		if data[p] == 115 {
+		if data[p] == 108 {
 			goto st142
 		}
 		goto tr118
@@ -4149,15 +4031,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof142
 		}
 	st_case_142:
-		if data[p] == 101 {
-			goto st143
-		}
-		goto tr118
-	st143:
-		if p++; p == pe {
-			goto _test_eof143
-		}
-	st_case_143:
 		switch data[p] {
 		case 13:
 			goto st114
@@ -4170,6 +4043,15 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st114
+		}
+		goto tr118
+	st143:
+		if p++; p == pe {
+			goto _test_eof143
+		}
+	st_case_143:
+		if data[p] == 114 {
+			goto st144
 		}
 		goto tr118
 	st144:
@@ -4186,7 +4068,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof145
 		}
 	st_case_145:
-		if data[p] == 108 {
+		if data[p] == 101 {
 			goto st146
 		}
 		goto tr118
@@ -4195,10 +4077,32 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof146
 		}
 	st_case_146:
-		if data[p] == 108 {
-			goto st147
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
+	tr144:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 147
+				top++
+				goto st176
+			}
+		}
+		goto st147
 	st147:
 		if p++; p == pe {
 			goto _test_eof147
@@ -4223,8 +4127,25 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof148
 		}
 	st_case_148:
-		if data[p] == 114 {
+		switch data[p] {
+		case 34:
 			goto st149
+		case 47:
+			goto st149
+		case 92:
+			goto st149
+		case 98:
+			goto st149
+		case 102:
+			goto st149
+		case 110:
+			goto st149
+		case 114:
+			goto st149
+		case 116:
+			goto st149
+		case 117:
+			goto st150
 		}
 		goto tr118
 	st149:
@@ -4232,16 +4153,31 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof149
 		}
 	st_case_149:
-		if data[p] == 117 {
-			goto st150
+		switch data[p] {
+		case 34:
+			goto st113
+		case 92:
+			goto st148
 		}
-		goto tr118
+		if data[p] <= 31 {
+			goto tr118
+		}
+		goto st112
 	st150:
 		if p++; p == pe {
 			goto _test_eof150
 		}
 	st_case_150:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st151
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st151
+			}
+		default:
 			goto st151
 		}
 		goto tr118
@@ -4250,49 +4186,35 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof151
 		}
 	st_case_151:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st152
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st152
+			}
+		default:
+			goto st152
 		}
 		goto tr118
-	tr144:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 152
-				top++
-				goto st186
-			}
-		}
-		goto st152
 	st152:
 		if p++; p == pe {
 			goto _test_eof152
 		}
 	st_case_152:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st153
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st153
+			}
+		default:
+			goto st153
 		}
 		goto tr118
 	st153:
@@ -4300,25 +4222,17 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof153
 		}
 	st_case_153:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st154
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st154
+			}
+		default:
 			goto st154
-		case 47:
-			goto st154
-		case 92:
-			goto st154
-		case 98:
-			goto st154
-		case 102:
-			goto st154
-		case 110:
-			goto st154
-		case 114:
-			goto st154
-		case 116:
-			goto st154
-		case 117:
-			goto st155
 		}
 		goto tr118
 	st154:
@@ -4330,7 +4244,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		case 34:
 			goto st113
 		case 92:
-			goto st153
+			goto st148
 		}
 		if data[p] <= 31 {
 			goto tr118
@@ -4341,17 +4255,11 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof155
 		}
 	st_case_155:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st156
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st156
-			}
-		default:
+		if data[p] == 48 {
 			goto st156
+		}
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st159
 		}
 		goto tr118
 	st156:
@@ -4359,53 +4267,68 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof156
 		}
 	st_case_156:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st157
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st157
-			}
-		default:
-			goto st157
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 93:
+			goto tr125
+		case 101:
+			goto tr174
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
+	tr173:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st157
 	st157:
 		if p++; p == pe {
 			goto _test_eof157
 		}
 	st_case_157:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st158
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st158
-			}
-		default:
-			goto st158
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
+	tr174:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st158
 	st158:
 		if p++; p == pe {
 			goto _test_eof158
 		}
 	st_case_158:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st159
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st159
-			}
-		default:
-			goto st159
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
 	st159:
@@ -4414,27 +4337,72 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		}
 	st_case_159:
 		switch data[p] {
-		case 34:
-			goto st113
-		case 92:
-			goto st153
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 93:
+			goto tr125
+		case 101:
+			goto tr174
 		}
-		if data[p] <= 31 {
-			goto tr118
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st160
+			}
+		case data[p] >= 9:
+			goto st114
 		}
-		goto st112
+		goto tr118
 	st160:
 		if p++; p == pe {
 			goto _test_eof160
 		}
 	st_case_160:
-		if data[p] == 48 {
-			goto st161
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 93:
+			goto tr125
+		case 101:
+			goto tr174
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st169
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st160
+			}
+		case data[p] >= 9:
+			goto st114
 		}
 		goto tr118
+	tr124:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 161
+				top++
+				goto st109
+			}
+		}
+		goto st161
 	st161:
 		if p++; p == pe {
 			goto _test_eof161
@@ -4447,14 +4415,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		case 44:
 			goto st115
-		case 46:
-			goto st162
-		case 69:
-			goto st165
 		case 93:
 			goto tr125
-		case 101:
-			goto st165
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st114
@@ -4465,7 +4427,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof162
 		}
 	st_case_162:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 97 {
 			goto st163
 		}
 		goto tr118
@@ -4474,27 +4436,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof163
 		}
 	st_case_163:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
-			goto st165
-		case 93:
-			goto tr125
-		case 101:
-			goto st165
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st164
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] == 108 {
+			goto st164
 		}
 		goto tr118
 	st164:
@@ -4502,27 +4445,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof164
 		}
 	st_case_164:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
+		if data[p] == 115 {
 			goto st165
-		case 93:
-			goto tr125
-		case 101:
-			goto st165
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st164
-			}
-		case data[p] >= 9:
-			goto st114
 		}
 		goto tr118
 	st165:
@@ -4530,14 +4454,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof165
 		}
 	st_case_165:
-		switch data[p] {
-		case 43:
+		if data[p] == 101 {
 			goto st166
-		case 45:
-			goto st166
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st167
 		}
 		goto tr118
 	st166:
@@ -4545,8 +4463,18 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof166
 		}
 	st_case_166:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st167
+		switch data[p] {
+		case 13:
+			goto st114
+		case 32:
+			goto st114
+		case 44:
+			goto st115
+		case 93:
+			goto tr125
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st114
 		}
 		goto tr118
 	st167:
@@ -4554,23 +4482,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof167
 		}
 	st_case_167:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st168
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] == 117 {
+			goto st168
 		}
 		goto tr118
 	st168:
@@ -4578,23 +4491,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof168
 		}
 	st_case_168:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st168
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] == 108 {
+			goto st169
 		}
 		goto tr118
 	st169:
@@ -4602,29 +4500,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof169
 		}
 	st_case_169:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st162
-		case 69:
-			goto st165
-		case 93:
-			goto tr125
-		case 101:
-			goto st165
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st170
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] == 108 {
+			goto st170
 		}
 		goto tr118
 	st170:
@@ -4639,48 +4516,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		case 44:
 			goto st115
-		case 46:
-			goto st162
-		case 69:
-			goto st165
-		case 93:
-			goto tr125
-		case 101:
-			goto st165
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st170
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr118
-	tr124:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 171
-				top++
-				goto st109
-			}
-		}
-		goto st171
-	st171:
-		if p++; p == pe {
-			goto _test_eof171
-		}
-	st_case_171:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
 		case 93:
 			goto tr125
 		}
@@ -4688,12 +4523,21 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		}
 		goto tr118
+	st171:
+		if p++; p == pe {
+			goto _test_eof171
+		}
+	st_case_171:
+		if data[p] == 114 {
+			goto st172
+		}
+		goto tr118
 	st172:
 		if p++; p == pe {
 			goto _test_eof172
 		}
 	st_case_172:
-		if data[p] == 97 {
+		if data[p] == 117 {
 			goto st173
 		}
 		goto tr118
@@ -4702,7 +4546,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof173
 		}
 	st_case_173:
-		if data[p] == 108 {
+		if data[p] == 101 {
 			goto st174
 		}
 		goto tr118
@@ -4711,116 +4555,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto _test_eof174
 		}
 	st_case_174:
-		if data[p] == 115 {
-			goto st175
-		}
-		goto tr118
-	st175:
-		if p++; p == pe {
-			goto _test_eof175
-		}
-	st_case_175:
-		if data[p] == 101 {
-			goto st176
-		}
-		goto tr118
-	st176:
-		if p++; p == pe {
-			goto _test_eof176
-		}
-	st_case_176:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr118
-	st177:
-		if p++; p == pe {
-			goto _test_eof177
-		}
-	st_case_177:
-		if data[p] == 117 {
-			goto st178
-		}
-		goto tr118
-	st178:
-		if p++; p == pe {
-			goto _test_eof178
-		}
-	st_case_178:
-		if data[p] == 108 {
-			goto st179
-		}
-		goto tr118
-	st179:
-		if p++; p == pe {
-			goto _test_eof179
-		}
-	st_case_179:
-		if data[p] == 108 {
-			goto st180
-		}
-		goto tr118
-	st180:
-		if p++; p == pe {
-			goto _test_eof180
-		}
-	st_case_180:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 93:
-			goto tr125
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr118
-	st181:
-		if p++; p == pe {
-			goto _test_eof181
-		}
-	st_case_181:
-		if data[p] == 114 {
-			goto st182
-		}
-		goto tr118
-	st182:
-		if p++; p == pe {
-			goto _test_eof182
-		}
-	st_case_182:
-		if data[p] == 117 {
-			goto st183
-		}
-		goto tr118
-	st183:
-		if p++; p == pe {
-			goto _test_eof183
-		}
-	st_case_183:
-		if data[p] == 101 {
-			goto st184
-		}
-		goto tr118
-	st184:
-		if p++; p == pe {
-			goto _test_eof184
-		}
-	st_case_184:
 		switch data[p] {
 		case 13:
 			goto st114
@@ -4841,17 +4575,17 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 185
+				stack[top] = 175
 				top++
-				goto st186
+				goto st176
 			}
 		}
-		goto st185
-	st185:
+		goto st175
+	st175:
 		if p++; p == pe {
-			goto _test_eof185
+			goto _test_eof175
 		}
-	st_case_185:
+	st_case_175:
 		switch data[p] {
 		case 13:
 			goto st114
@@ -4866,6 +4600,210 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st114
 		}
 		goto tr118
+	st176:
+		if p++; p == pe {
+			goto _test_eof176
+		}
+	st_case_176:
+		switch data[p] {
+		case 13:
+			goto st177
+		case 32:
+			goto st177
+		case 34:
+			goto st178
+		case 125:
+			goto tr189
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st177
+		}
+		goto tr186
+	st177:
+		if p++; p == pe {
+			goto _test_eof177
+		}
+	st_case_177:
+		switch data[p] {
+		case 13:
+			goto st177
+		case 32:
+			goto st177
+		case 34:
+			goto st178
+		case 125:
+			goto tr189
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st177
+		}
+		goto tr186
+	st178:
+		if p++; p == pe {
+			goto _test_eof178
+		}
+	st_case_178:
+		switch data[p] {
+		case 34:
+			goto st180
+		case 92:
+			goto st262
+		}
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st179
+	st179:
+		if p++; p == pe {
+			goto _test_eof179
+		}
+	st_case_179:
+		switch data[p] {
+		case 34:
+			goto st180
+		case 92:
+			goto st262
+		}
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st179
+	st180:
+		if p++; p == pe {
+			goto _test_eof180
+		}
+	st_case_180:
+		switch data[p] {
+		case 13:
+			goto st181
+		case 32:
+			goto st181
+		case 58:
+			goto st182
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st181
+		}
+		goto tr186
+	st181:
+		if p++; p == pe {
+			goto _test_eof181
+		}
+	st_case_181:
+		switch data[p] {
+		case 13:
+			goto st181
+		case 32:
+			goto st181
+		case 58:
+			goto st182
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st181
+		}
+		goto tr186
+	st182:
+		if p++; p == pe {
+			goto _test_eof182
+		}
+	st_case_182:
+		switch data[p] {
+		case 13:
+			goto st183
+		case 32:
+			goto st183
+		case 34:
+			goto st184
+		case 45:
+			goto st241
+		case 48:
+			goto st242
+		case 91:
+			goto tr200
+		case 102:
+			goto st248
+		case 110:
+			goto st253
+		case 116:
+			goto st257
+		case 123:
+			goto tr204
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st245
+			}
+		case data[p] >= 9:
+			goto st183
+		}
+		goto tr186
+	st183:
+		if p++; p == pe {
+			goto _test_eof183
+		}
+	st_case_183:
+		switch data[p] {
+		case 13:
+			goto st183
+		case 32:
+			goto st183
+		case 34:
+			goto st184
+		case 45:
+			goto st241
+		case 48:
+			goto st242
+		case 91:
+			goto tr200
+		case 102:
+			goto st248
+		case 110:
+			goto st253
+		case 116:
+			goto st257
+		case 123:
+			goto tr204
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st245
+			}
+		case data[p] >= 9:
+			goto st183
+		}
+		goto tr186
+	st184:
+		if p++; p == pe {
+			goto _test_eof184
+		}
+	st_case_184:
+		switch data[p] {
+		case 34:
+			goto st186
+		case 92:
+			goto st234
+		}
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st185
+	st185:
+		if p++; p == pe {
+			goto _test_eof185
+		}
+	st_case_185:
+		switch data[p] {
+		case 34:
+			goto st186
+		case 92:
+			goto st234
+		}
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st185
 	st186:
 		if p++; p == pe {
 			goto _test_eof186
@@ -4876,15 +4814,15 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st187
 		case 32:
 			goto st187
-		case 34:
+		case 44:
 			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st187
 		}
-		goto tr196
+		goto tr186
 	st187:
 		if p++; p == pe {
 			goto _test_eof187
@@ -4895,79 +4833,79 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st187
 		case 32:
 			goto st187
-		case 34:
+		case 44:
 			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
 		if 9 <= data[p] && data[p] <= 10 {
 			goto st187
 		}
-		goto tr196
+		goto tr186
 	st188:
 		if p++; p == pe {
 			goto _test_eof188
 		}
 	st_case_188:
 		switch data[p] {
+		case 13:
+			goto st189
+		case 32:
+			goto st189
 		case 34:
 			goto st190
-		case 92:
-			goto st282
 		}
-		if data[p] <= 31 {
-			goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st189
 		}
-		goto st189
+		goto tr186
 	st189:
 		if p++; p == pe {
 			goto _test_eof189
 		}
 	st_case_189:
 		switch data[p] {
+		case 13:
+			goto st189
+		case 32:
+			goto st189
 		case 34:
 			goto st190
-		case 92:
-			goto st282
 		}
-		if data[p] <= 31 {
-			goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st189
 		}
-		goto st189
+		goto tr186
 	st190:
 		if p++; p == pe {
 			goto _test_eof190
 		}
 	st_case_190:
 		switch data[p] {
-		case 13:
-			goto st191
-		case 32:
-			goto st191
-		case 58:
+		case 34:
 			goto st192
+		case 92:
+			goto st227
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st191
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st191
 	st191:
 		if p++; p == pe {
 			goto _test_eof191
 		}
 	st_case_191:
 		switch data[p] {
-		case 13:
-			goto st191
-		case 32:
-			goto st191
-		case 58:
+		case 34:
 			goto st192
+		case 92:
+			goto st227
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st191
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st191
 	st192:
 		if p++; p == pe {
 			goto _test_eof192
@@ -4978,32 +4916,13 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st193
 		case 32:
 			goto st193
-		case 34:
+		case 58:
 			goto st194
-		case 45:
-			goto st256
-		case 48:
-			goto st257
-		case 91:
-			goto tr210
-		case 102:
-			goto st268
-		case 110:
-			goto st273
-		case 116:
-			goto st277
-		case 123:
-			goto tr214
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st265
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st193
 		}
-		goto tr196
+		goto tr186
 	st193:
 		if p++; p == pe {
 			goto _test_eof193
@@ -5014,100 +4933,115 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 			goto st193
 		case 32:
 			goto st193
-		case 34:
+		case 58:
 			goto st194
-		case 45:
-			goto st256
-		case 48:
-			goto st257
-		case 91:
-			goto tr210
-		case 102:
-			goto st268
-		case 110:
-			goto st273
-		case 116:
-			goto st277
-		case 123:
-			goto tr214
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st265
-			}
-		case data[p] >= 9:
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st193
 		}
-		goto tr196
+		goto tr186
 	st194:
 		if p++; p == pe {
 			goto _test_eof194
 		}
 	st_case_194:
 		switch data[p] {
+		case 13:
+			goto st195
+		case 32:
+			goto st195
 		case 34:
 			goto st196
-		case 92:
-			goto st249
+		case 45:
+			goto st206
+		case 48:
+			goto st207
+		case 91:
+			goto tr222
+		case 102:
+			goto st213
+		case 110:
+			goto st218
+		case 116:
+			goto st222
+		case 123:
+			goto tr226
 		}
-		if data[p] <= 31 {
-			goto tr196
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st210
+			}
+		case data[p] >= 9:
+			goto st195
 		}
-		goto st195
+		goto tr186
 	st195:
 		if p++; p == pe {
 			goto _test_eof195
 		}
 	st_case_195:
 		switch data[p] {
+		case 13:
+			goto st195
+		case 32:
+			goto st195
 		case 34:
 			goto st196
-		case 92:
-			goto st249
+		case 45:
+			goto st206
+		case 48:
+			goto st207
+		case 91:
+			goto tr222
+		case 102:
+			goto st213
+		case 110:
+			goto st218
+		case 116:
+			goto st222
+		case 123:
+			goto tr226
 		}
-		if data[p] <= 31 {
-			goto tr196
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st210
+			}
+		case data[p] >= 9:
+			goto st195
 		}
-		goto st195
+		goto tr186
 	st196:
 		if p++; p == pe {
 			goto _test_eof196
 		}
 	st_case_196:
 		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
+		case 34:
 			goto st198
-		case 125:
-			goto tr199
+		case 92:
+			goto st199
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st197
 	st197:
 		if p++; p == pe {
 			goto _test_eof197
 		}
 	st_case_197:
 		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
+		case 34:
 			goto st198
-		case 125:
-			goto tr199
+		case 92:
+			goto st199
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st197
 	st198:
 		if p++; p == pe {
 			goto _test_eof198
@@ -5115,33 +5049,57 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_198:
 		switch data[p] {
 		case 13:
-			goto st199
+			goto st187
 		case 32:
-			goto st199
-		case 34:
-			goto st200
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st199
+			goto st187
 		}
-		goto tr196
+		goto tr186
+	tr189:
+		{
+			top--
+			cs = stack[top]
+			goto _again
+		}
+		goto st272
+	st272:
+		if p++; p == pe {
+			goto _test_eof272
+		}
+	st_case_272:
+		goto st0
 	st199:
 		if p++; p == pe {
 			goto _test_eof199
 		}
 	st_case_199:
 		switch data[p] {
-		case 13:
-			goto st199
-		case 32:
-			goto st199
 		case 34:
 			goto st200
+		case 47:
+			goto st200
+		case 92:
+			goto st200
+		case 98:
+			goto st200
+		case 102:
+			goto st200
+		case 110:
+			goto st200
+		case 114:
+			goto st200
+		case 116:
+			goto st200
+		case 117:
+			goto st201
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st199
-		}
-		goto tr196
+		goto tr186
 	st200:
 		if p++; p == pe {
 			goto _test_eof200
@@ -5149,165 +5107,141 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_200:
 		switch data[p] {
 		case 34:
-			goto st202
+			goto st198
 		case 92:
-			goto st242
+			goto st199
 		}
 		if data[p] <= 31 {
-			goto tr196
+			goto tr186
 		}
-		goto st201
+		goto st197
 	st201:
 		if p++; p == pe {
 			goto _test_eof201
 		}
 	st_case_201:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st202
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st202
+			}
+		default:
 			goto st202
-		case 92:
-			goto st242
 		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st201
+		goto tr186
 	st202:
 		if p++; p == pe {
 			goto _test_eof202
 		}
 	st_case_202:
-		switch data[p] {
-		case 13:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st203
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st203
+			}
+		default:
 			goto st203
-		case 32:
-			goto st203
-		case 58:
-			goto st204
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st203
-		}
-		goto tr196
+		goto tr186
 	st203:
 		if p++; p == pe {
 			goto _test_eof203
 		}
 	st_case_203:
-		switch data[p] {
-		case 13:
-			goto st203
-		case 32:
-			goto st203
-		case 58:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st204
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st204
+			}
+		default:
 			goto st204
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st203
-		}
-		goto tr196
+		goto tr186
 	st204:
 		if p++; p == pe {
 			goto _test_eof204
 		}
 	st_case_204:
-		switch data[p] {
-		case 13:
-			goto st205
-		case 32:
-			goto st205
-		case 34:
-			goto st206
-		case 45:
-			goto st216
-		case 48:
-			goto st217
-		case 91:
-			goto tr232
-		case 102:
-			goto st228
-		case 110:
-			goto st233
-		case 116:
-			goto st237
-		case 123:
-			goto tr236
-		}
 		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st225
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st205
 			}
-		case data[p] >= 9:
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st205
+			}
+		default:
 			goto st205
 		}
-		goto tr196
+		goto tr186
 	st205:
 		if p++; p == pe {
 			goto _test_eof205
 		}
 	st_case_205:
 		switch data[p] {
-		case 13:
-			goto st205
-		case 32:
-			goto st205
 		case 34:
-			goto st206
-		case 45:
-			goto st216
-		case 48:
-			goto st217
-		case 91:
-			goto tr232
-		case 102:
-			goto st228
-		case 110:
-			goto st233
-		case 116:
-			goto st237
-		case 123:
-			goto tr236
+			goto st198
+		case 92:
+			goto st199
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st225
-			}
-		case data[p] >= 9:
-			goto st205
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st197
 	st206:
 		if p++; p == pe {
 			goto _test_eof206
 		}
 	st_case_206:
-		switch data[p] {
-		case 34:
-			goto st208
-		case 92:
-			goto st209
+		if data[p] == 48 {
+			goto st207
 		}
-		if data[p] <= 31 {
-			goto tr196
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st210
 		}
-		goto st207
+		goto tr186
 	st207:
 		if p++; p == pe {
 			goto _test_eof207
 		}
 	st_case_207:
 		switch data[p] {
-		case 34:
-			goto st208
-		case 92:
-			goto st209
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr236
+		case 69:
+			goto tr237
+		case 101:
+			goto tr237
+		case 125:
+			goto tr189
 		}
-		if data[p] <= 31 {
-			goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto st207
+		goto tr186
+	tr236:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st208
 	st208:
 		if p++; p == pe {
 			goto _test_eof208
@@ -5315,171 +5249,167 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_208:
 		switch data[p] {
 		case 13:
-			goto st197
+			goto st187
 		case 32:
-			goto st197
+			goto st187
 		case 44:
-			goto st198
+			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+			goto st187
 		}
-		goto tr196
-	tr199:
-		{
-			top--
-			cs = stack[top]
-			goto _again
-		}
-		goto st292
-	st292:
-		if p++; p == pe {
-			goto _test_eof292
-		}
-	st_case_292:
-		goto st0
+		goto tr186
+	tr237:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st209
 	st209:
 		if p++; p == pe {
 			goto _test_eof209
 		}
 	st_case_209:
 		switch data[p] {
-		case 34:
-			goto st210
-		case 47:
-			goto st210
-		case 92:
-			goto st210
-		case 98:
-			goto st210
-		case 102:
-			goto st210
-		case 110:
-			goto st210
-		case 114:
-			goto st210
-		case 116:
-			goto st210
-		case 117:
-			goto st211
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
 	st210:
 		if p++; p == pe {
 			goto _test_eof210
 		}
 	st_case_210:
 		switch data[p] {
-		case 34:
-			goto st208
-		case 92:
-			goto st209
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr236
+		case 69:
+			goto tr237
+		case 101:
+			goto tr237
+		case 125:
+			goto tr189
 		}
-		if data[p] <= 31 {
-			goto tr196
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st211
+			}
+		case data[p] >= 9:
+			goto st187
 		}
-		goto st207
+		goto tr186
 	st211:
 		if p++; p == pe {
 			goto _test_eof211
 		}
 	st_case_211:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st212
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st212
-			}
-		default:
-			goto st212
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr236
+		case 69:
+			goto tr237
+		case 101:
+			goto tr237
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st211
+			}
+		case data[p] >= 9:
+			goto st187
+		}
+		goto tr186
+	tr222:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 212
+				top++
+				goto st109
+			}
+		}
+		goto st212
 	st212:
 		if p++; p == pe {
 			goto _test_eof212
 		}
 	st_case_212:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st213
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st213
-			}
-		default:
-			goto st213
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
 	st213:
 		if p++; p == pe {
 			goto _test_eof213
 		}
 	st_case_213:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st214
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st214
-			}
-		default:
+		if data[p] == 97 {
 			goto st214
 		}
-		goto tr196
+		goto tr186
 	st214:
 		if p++; p == pe {
 			goto _test_eof214
 		}
 	st_case_214:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st215
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st215
-			}
-		default:
+		if data[p] == 108 {
 			goto st215
 		}
-		goto tr196
+		goto tr186
 	st215:
 		if p++; p == pe {
 			goto _test_eof215
 		}
 	st_case_215:
-		switch data[p] {
-		case 34:
-			goto st208
-		case 92:
-			goto st209
+		if data[p] == 115 {
+			goto st216
 		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st207
+		goto tr186
 	st216:
 		if p++; p == pe {
 			goto _test_eof216
 		}
 	st_case_216:
-		if data[p] == 48 {
+		if data[p] == 101 {
 			goto st217
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st225
-		}
-		goto tr196
+		goto tr186
 	st217:
 		if p++; p == pe {
 			goto _test_eof217
@@ -5487,161 +5417,91 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_217:
 		switch data[p] {
 		case 13:
-			goto st197
+			goto st187
 		case 32:
-			goto st197
+			goto st187
 		case 44:
-			goto st198
-		case 46:
-			goto st218
-		case 69:
-			goto st221
-		case 101:
-			goto st221
+			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+			goto st187
 		}
-		goto tr196
+		goto tr186
 	st218:
 		if p++; p == pe {
 			goto _test_eof218
 		}
 	st_case_218:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 117 {
 			goto st219
 		}
-		goto tr196
+		goto tr186
 	st219:
 		if p++; p == pe {
 			goto _test_eof219
 		}
 	st_case_219:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 69:
-			goto st221
-		case 101:
-			goto st221
-		case 125:
-			goto tr199
+		if data[p] == 108 {
+			goto st220
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st220
-			}
-		case data[p] >= 9:
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st220:
 		if p++; p == pe {
 			goto _test_eof220
 		}
 	st_case_220:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 69:
+		if data[p] == 108 {
 			goto st221
-		case 101:
-			goto st221
-		case 125:
-			goto tr199
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st220
-			}
-		case data[p] >= 9:
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st221:
 		if p++; p == pe {
 			goto _test_eof221
 		}
 	st_case_221:
 		switch data[p] {
-		case 43:
-			goto st222
-		case 45:
-			goto st222
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st223
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto tr196
+		goto tr186
 	st222:
 		if p++; p == pe {
 			goto _test_eof222
 		}
 	st_case_222:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 114 {
 			goto st223
 		}
-		goto tr196
+		goto tr186
 	st223:
 		if p++; p == pe {
 			goto _test_eof223
 		}
 	st_case_223:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		if data[p] == 117 {
+			goto st224
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st224
-			}
-		case data[p] >= 9:
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st224:
 		if p++; p == pe {
 			goto _test_eof224
 		}
 	st_case_224:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		if data[p] == 101 {
+			goto st225
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st224
-			}
-		case data[p] >= 9:
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st225:
 		if p++; p == pe {
 			goto _test_eof225
@@ -5649,29 +5509,30 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_225:
 		switch data[p] {
 		case 13:
-			goto st197
+			goto st187
 		case 32:
-			goto st197
+			goto st187
 		case 44:
-			goto st198
-		case 46:
-			goto st218
-		case 69:
-			goto st221
-		case 101:
-			goto st221
+			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st226
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
+	tr226:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
-		case data[p] >= 9:
-			goto st197
+			{
+				stack[top] = 226
+				top++
+				goto st176
+			}
 		}
-		goto tr196
+		goto st226
 	st226:
 		if p++; p == pe {
 			goto _test_eof226
@@ -5679,568 +5540,574 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_226:
 		switch data[p] {
 		case 13:
-			goto st197
+			goto st187
 		case 32:
-			goto st197
+			goto st187
 		case 44:
-			goto st198
-		case 46:
-			goto st218
-		case 69:
-			goto st221
-		case 101:
-			goto st221
+			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st226
-			}
-		case data[p] >= 9:
-			goto st197
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto tr196
-	tr232:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 227
-				top++
-				goto st109
-			}
-		}
-		goto st227
+		goto tr186
 	st227:
 		if p++; p == pe {
 			goto _test_eof227
 		}
 	st_case_227:
 		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		case 34:
+			goto st228
+		case 47:
+			goto st228
+		case 92:
+			goto st228
+		case 98:
+			goto st228
+		case 102:
+			goto st228
+		case 110:
+			goto st228
+		case 114:
+			goto st228
+		case 116:
+			goto st228
+		case 117:
+			goto st229
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st228:
 		if p++; p == pe {
 			goto _test_eof228
 		}
 	st_case_228:
-		if data[p] == 97 {
-			goto st229
+		switch data[p] {
+		case 34:
+			goto st192
+		case 92:
+			goto st227
 		}
-		goto tr196
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st191
 	st229:
 		if p++; p == pe {
 			goto _test_eof229
 		}
 	st_case_229:
-		if data[p] == 108 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st230
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st230
+			}
+		default:
 			goto st230
 		}
-		goto tr196
+		goto tr186
 	st230:
 		if p++; p == pe {
 			goto _test_eof230
 		}
 	st_case_230:
-		if data[p] == 115 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st231
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st231
+			}
+		default:
 			goto st231
 		}
-		goto tr196
+		goto tr186
 	st231:
 		if p++; p == pe {
 			goto _test_eof231
 		}
 	st_case_231:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st232
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st232
+			}
+		default:
 			goto st232
 		}
-		goto tr196
+		goto tr186
 	st232:
 		if p++; p == pe {
 			goto _test_eof232
 		}
 	st_case_232:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st233
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st233
+			}
+		default:
+			goto st233
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st233:
 		if p++; p == pe {
 			goto _test_eof233
 		}
 	st_case_233:
-		if data[p] == 117 {
-			goto st234
+		switch data[p] {
+		case 34:
+			goto st192
+		case 92:
+			goto st227
 		}
-		goto tr196
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st191
 	st234:
 		if p++; p == pe {
 			goto _test_eof234
 		}
 	st_case_234:
-		if data[p] == 108 {
+		switch data[p] {
+		case 34:
 			goto st235
+		case 47:
+			goto st235
+		case 92:
+			goto st235
+		case 98:
+			goto st235
+		case 102:
+			goto st235
+		case 110:
+			goto st235
+		case 114:
+			goto st235
+		case 116:
+			goto st235
+		case 117:
+			goto st236
 		}
-		goto tr196
+		goto tr186
 	st235:
 		if p++; p == pe {
 			goto _test_eof235
 		}
 	st_case_235:
-		if data[p] == 108 {
-			goto st236
+		switch data[p] {
+		case 34:
+			goto st186
+		case 92:
+			goto st234
 		}
-		goto tr196
+		if data[p] <= 31 {
+			goto tr186
+		}
+		goto st185
 	st236:
 		if p++; p == pe {
 			goto _test_eof236
 		}
 	st_case_236:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st237
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st237
+			}
+		default:
+			goto st237
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st237:
 		if p++; p == pe {
 			goto _test_eof237
 		}
 	st_case_237:
-		if data[p] == 114 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st238
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st238
+			}
+		default:
 			goto st238
 		}
-		goto tr196
+		goto tr186
 	st238:
 		if p++; p == pe {
 			goto _test_eof238
 		}
 	st_case_238:
-		if data[p] == 117 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st239
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st239
+			}
+		default:
 			goto st239
 		}
-		goto tr196
+		goto tr186
 	st239:
 		if p++; p == pe {
 			goto _test_eof239
 		}
 	st_case_239:
-		if data[p] == 101 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st240
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st240
+			}
+		default:
 			goto st240
 		}
-		goto tr196
+		goto tr186
 	st240:
 		if p++; p == pe {
 			goto _test_eof240
 		}
 	st_case_240:
 		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		case 34:
+			goto st186
+		case 92:
+			goto st234
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
-	tr236:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 241
-				top++
-				goto st186
-			}
-		}
-		goto st241
+		goto st185
 	st241:
 		if p++; p == pe {
 			goto _test_eof241
 		}
 	st_case_241:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		if data[p] == 48 {
+			goto st242
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st245
 		}
-		goto tr196
+		goto tr186
 	st242:
 		if p++; p == pe {
 			goto _test_eof242
 		}
 	st_case_242:
 		switch data[p] {
-		case 34:
-			goto st243
-		case 47:
-			goto st243
-		case 92:
-			goto st243
-		case 98:
-			goto st243
-		case 102:
-			goto st243
-		case 110:
-			goto st243
-		case 114:
-			goto st243
-		case 116:
-			goto st243
-		case 117:
-			goto st244
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr261
+		case 69:
+			goto tr262
+		case 101:
+			goto tr262
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
+	tr261:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st243
 	st243:
 		if p++; p == pe {
 			goto _test_eof243
 		}
 	st_case_243:
 		switch data[p] {
-		case 34:
-			goto st202
-		case 92:
-			goto st242
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		if data[p] <= 31 {
-			goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto st201
+		goto tr186
+	tr262:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st244
 	st244:
 		if p++; p == pe {
 			goto _test_eof244
 		}
 	st_case_244:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st245
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st245
-			}
-		default:
-			goto st245
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
 	st245:
 		if p++; p == pe {
 			goto _test_eof245
 		}
 	st_case_245:
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr261
+		case 69:
+			goto tr262
+		case 101:
+			goto tr262
+		case 125:
+			goto tr189
+		}
 		switch {
-		case data[p] < 65:
+		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st246
 			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st246
-			}
-		default:
-			goto st246
+		case data[p] >= 9:
+			goto st187
 		}
-		goto tr196
+		goto tr186
 	st246:
 		if p++; p == pe {
 			goto _test_eof246
 		}
 	st_case_246:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st247
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st247
-			}
-		default:
-			goto st247
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 46:
+			goto tr261
+		case 69:
+			goto tr262
+		case 101:
+			goto tr262
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st246
+			}
+		case data[p] >= 9:
+			goto st187
+		}
+		goto tr186
+	tr200:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 247
+				top++
+				goto st109
+			}
+		}
+		goto st247
 	st247:
 		if p++; p == pe {
 			goto _test_eof247
 		}
 	st_case_247:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st248
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st248
-			}
-		default:
-			goto st248
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
 	st248:
 		if p++; p == pe {
 			goto _test_eof248
 		}
 	st_case_248:
-		switch data[p] {
-		case 34:
-			goto st202
-		case 92:
-			goto st242
+		if data[p] == 97 {
+			goto st249
 		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st201
+		goto tr186
 	st249:
 		if p++; p == pe {
 			goto _test_eof249
 		}
 	st_case_249:
-		switch data[p] {
-		case 34:
+		if data[p] == 108 {
 			goto st250
-		case 47:
-			goto st250
-		case 92:
-			goto st250
-		case 98:
-			goto st250
-		case 102:
-			goto st250
-		case 110:
-			goto st250
-		case 114:
-			goto st250
-		case 116:
-			goto st250
-		case 117:
-			goto st251
 		}
-		goto tr196
+		goto tr186
 	st250:
 		if p++; p == pe {
 			goto _test_eof250
 		}
 	st_case_250:
-		switch data[p] {
-		case 34:
-			goto st196
-		case 92:
-			goto st249
+		if data[p] == 115 {
+			goto st251
 		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st195
+		goto tr186
 	st251:
 		if p++; p == pe {
 			goto _test_eof251
 		}
 	st_case_251:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st252
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st252
-			}
-		default:
+		if data[p] == 101 {
 			goto st252
 		}
-		goto tr196
+		goto tr186
 	st252:
 		if p++; p == pe {
 			goto _test_eof252
 		}
 	st_case_252:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st253
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st253
-			}
-		default:
-			goto st253
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		goto tr196
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
 	st253:
 		if p++; p == pe {
 			goto _test_eof253
 		}
 	st_case_253:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st254
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st254
-			}
-		default:
+		if data[p] == 117 {
 			goto st254
 		}
-		goto tr196
+		goto tr186
 	st254:
 		if p++; p == pe {
 			goto _test_eof254
 		}
 	st_case_254:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st255
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st255
-			}
-		default:
+		if data[p] == 108 {
 			goto st255
 		}
-		goto tr196
+		goto tr186
 	st255:
 		if p++; p == pe {
 			goto _test_eof255
 		}
 	st_case_255:
-		switch data[p] {
-		case 34:
-			goto st196
-		case 92:
-			goto st249
+		if data[p] == 108 {
+			goto st256
 		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st195
+		goto tr186
 	st256:
 		if p++; p == pe {
 			goto _test_eof256
 		}
 	st_case_256:
-		if data[p] == 48 {
-			goto st257
+		switch data[p] {
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st265
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto tr196
+		goto tr186
 	st257:
 		if p++; p == pe {
 			goto _test_eof257
 		}
 	st_case_257:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 46:
+		if data[p] == 114 {
 			goto st258
-		case 69:
-			goto st261
-		case 101:
-			goto st261
-		case 125:
-			goto tr199
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st258:
 		if p++; p == pe {
 			goto _test_eof258
 		}
 	st_case_258:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 117 {
 			goto st259
 		}
-		goto tr196
+		goto tr186
 	st259:
 		if p++; p == pe {
 			goto _test_eof259
 		}
 	st_case_259:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 69:
-			goto st261
-		case 101:
-			goto st261
-		case 125:
-			goto tr199
+		if data[p] == 101 {
+			goto st260
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st260
-			}
-		case data[p] >= 9:
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st260:
 		if p++; p == pe {
 			goto _test_eof260
@@ -6248,496 +6115,177 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	st_case_260:
 		switch data[p] {
 		case 13:
-			goto st197
+			goto st187
 		case 32:
-			goto st197
+			goto st187
 		case 44:
-			goto st198
-		case 69:
-			goto st261
-		case 101:
-			goto st261
+			goto st188
 		case 125:
-			goto tr199
+			goto tr189
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st260
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
+		}
+		goto tr186
+	tr204:
+		{
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
-		case data[p] >= 9:
-			goto st197
+			{
+				stack[top] = 261
+				top++
+				goto st176
+			}
 		}
-		goto tr196
+		goto st261
 	st261:
 		if p++; p == pe {
 			goto _test_eof261
 		}
 	st_case_261:
 		switch data[p] {
-		case 43:
-			goto st262
-		case 45:
-			goto st262
+		case 13:
+			goto st187
+		case 32:
+			goto st187
+		case 44:
+			goto st188
+		case 125:
+			goto tr189
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st263
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st187
 		}
-		goto tr196
+		goto tr186
 	st262:
 		if p++; p == pe {
 			goto _test_eof262
 		}
 	st_case_262:
-		if 48 <= data[p] && data[p] <= 57 {
+		switch data[p] {
+		case 34:
 			goto st263
+		case 47:
+			goto st263
+		case 92:
+			goto st263
+		case 98:
+			goto st263
+		case 102:
+			goto st263
+		case 110:
+			goto st263
+		case 114:
+			goto st263
+		case 116:
+			goto st263
+		case 117:
+			goto st264
 		}
-		goto tr196
+		goto tr186
 	st263:
 		if p++; p == pe {
 			goto _test_eof263
 		}
 	st_case_263:
 		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		case 34:
+			goto st180
+		case 92:
+			goto st262
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st264
-			}
-		case data[p] >= 9:
-			goto st197
+		if data[p] <= 31 {
+			goto tr186
 		}
-		goto tr196
+		goto st179
 	st264:
 		if p++; p == pe {
 			goto _test_eof264
 		}
 	st_case_264:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st264
+				goto st265
 			}
-		case data[p] >= 9:
-			goto st197
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st265
+			}
+		default:
+			goto st265
 		}
-		goto tr196
+		goto tr186
 	st265:
 		if p++; p == pe {
 			goto _test_eof265
 		}
 	st_case_265:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 46:
-			goto st258
-		case 69:
-			goto st261
-		case 101:
-			goto st261
-		case 125:
-			goto tr199
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st266
 			}
-		case data[p] >= 9:
-			goto st197
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st266
+			}
+		default:
+			goto st266
 		}
-		goto tr196
+		goto tr186
 	st266:
 		if p++; p == pe {
 			goto _test_eof266
 		}
 	st_case_266:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 46:
-			goto st258
-		case 69:
-			goto st261
-		case 101:
-			goto st261
-		case 125:
-			goto tr199
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st266
+				goto st267
 			}
-		case data[p] >= 9:
-			goto st197
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st267
+			}
+		default:
+			goto st267
 		}
-		goto tr196
-	tr210:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 267
-				top++
-				goto st109
-			}
-		}
-		goto st267
+		goto tr186
 	st267:
 		if p++; p == pe {
 			goto _test_eof267
 		}
 	st_case_267:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st268
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st268
+			}
+		default:
+			goto st268
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
+		goto tr186
 	st268:
 		if p++; p == pe {
 			goto _test_eof268
 		}
 	st_case_268:
-		if data[p] == 97 {
-			goto st269
-		}
-		goto tr196
-	st269:
-		if p++; p == pe {
-			goto _test_eof269
-		}
-	st_case_269:
-		if data[p] == 108 {
-			goto st270
-		}
-		goto tr196
-	st270:
-		if p++; p == pe {
-			goto _test_eof270
-		}
-	st_case_270:
-		if data[p] == 115 {
-			goto st271
-		}
-		goto tr196
-	st271:
-		if p++; p == pe {
-			goto _test_eof271
-		}
-	st_case_271:
-		if data[p] == 101 {
-			goto st272
-		}
-		goto tr196
-	st272:
-		if p++; p == pe {
-			goto _test_eof272
-		}
-	st_case_272:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
-	st273:
-		if p++; p == pe {
-			goto _test_eof273
-		}
-	st_case_273:
-		if data[p] == 117 {
-			goto st274
-		}
-		goto tr196
-	st274:
-		if p++; p == pe {
-			goto _test_eof274
-		}
-	st_case_274:
-		if data[p] == 108 {
-			goto st275
-		}
-		goto tr196
-	st275:
-		if p++; p == pe {
-			goto _test_eof275
-		}
-	st_case_275:
-		if data[p] == 108 {
-			goto st276
-		}
-		goto tr196
-	st276:
-		if p++; p == pe {
-			goto _test_eof276
-		}
-	st_case_276:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
-	st277:
-		if p++; p == pe {
-			goto _test_eof277
-		}
-	st_case_277:
-		if data[p] == 114 {
-			goto st278
-		}
-		goto tr196
-	st278:
-		if p++; p == pe {
-			goto _test_eof278
-		}
-	st_case_278:
-		if data[p] == 117 {
-			goto st279
-		}
-		goto tr196
-	st279:
-		if p++; p == pe {
-			goto _test_eof279
-		}
-	st_case_279:
-		if data[p] == 101 {
-			goto st280
-		}
-		goto tr196
-	st280:
-		if p++; p == pe {
-			goto _test_eof280
-		}
-	st_case_280:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
-	tr214:
-		{
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 281
-				top++
-				goto st186
-			}
-		}
-		goto st281
-	st281:
-		if p++; p == pe {
-			goto _test_eof281
-		}
-	st_case_281:
-		switch data[p] {
-		case 13:
-			goto st197
-		case 32:
-			goto st197
-		case 44:
-			goto st198
-		case 125:
-			goto tr199
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st197
-		}
-		goto tr196
-	st282:
-		if p++; p == pe {
-			goto _test_eof282
-		}
-	st_case_282:
 		switch data[p] {
 		case 34:
-			goto st283
-		case 47:
-			goto st283
+			goto st180
 		case 92:
-			goto st283
-		case 98:
-			goto st283
-		case 102:
-			goto st283
-		case 110:
-			goto st283
-		case 114:
-			goto st283
-		case 116:
-			goto st283
-		case 117:
-			goto st284
-		}
-		goto tr196
-	st283:
-		if p++; p == pe {
-			goto _test_eof283
-		}
-	st_case_283:
-		switch data[p] {
-		case 34:
-			goto st190
-		case 92:
-			goto st282
+			goto st262
 		}
 		if data[p] <= 31 {
-			goto tr196
+			goto tr186
 		}
-		goto st189
-	st284:
-		if p++; p == pe {
-			goto _test_eof284
-		}
-	st_case_284:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st285
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st285
-			}
-		default:
-			goto st285
-		}
-		goto tr196
-	st285:
-		if p++; p == pe {
-			goto _test_eof285
-		}
-	st_case_285:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st286
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st286
-			}
-		default:
-			goto st286
-		}
-		goto tr196
-	st286:
-		if p++; p == pe {
-			goto _test_eof286
-		}
-	st_case_286:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st287
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st287
-			}
-		default:
-			goto st287
-		}
-		goto tr196
-	st287:
-		if p++; p == pe {
-			goto _test_eof287
-		}
-	st_case_287:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st288
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st288
-			}
-		default:
-			goto st288
-		}
-		goto tr196
-	st288:
-		if p++; p == pe {
-			goto _test_eof288
-		}
-	st_case_288:
-		switch data[p] {
-		case 34:
-			goto st190
-		case 92:
-			goto st282
-		}
-		if data[p] <= 31 {
-			goto tr196
-		}
-		goto st189
+		goto st179
 	st_out:
 	_test_eof1:
 		cs = 1
@@ -6754,8 +6302,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	_test_eof5:
 		cs = 5
 		goto _test_eof
-	_test_eof289:
-		cs = 289
+	_test_eof269:
+		cs = 269
 		goto _test_eof
 	_test_eof6:
 		cs = 6
@@ -6826,8 +6374,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	_test_eof28:
 		cs = 28
 		goto _test_eof
-	_test_eof290:
-		cs = 290
+	_test_eof270:
+		cs = 270
 		goto _test_eof
 	_test_eof29:
 		cs = 29
@@ -7102,8 +6650,8 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	_test_eof119:
 		cs = 119
 		goto _test_eof
-	_test_eof291:
-		cs = 291
+	_test_eof271:
+		cs = 271
 		goto _test_eof
 	_test_eof120:
 		cs = 120
@@ -7342,6 +6890,9 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	_test_eof198:
 		cs = 198
 		goto _test_eof
+	_test_eof272:
+		cs = 272
+		goto _test_eof
 	_test_eof199:
 		cs = 199
 		goto _test_eof
@@ -7371,9 +6922,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 		goto _test_eof
 	_test_eof208:
 		cs = 208
-		goto _test_eof
-	_test_eof292:
-		cs = 292
 		goto _test_eof
 	_test_eof209:
 		cs = 209
@@ -7555,66 +7103,6 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 	_test_eof268:
 		cs = 268
 		goto _test_eof
-	_test_eof269:
-		cs = 269
-		goto _test_eof
-	_test_eof270:
-		cs = 270
-		goto _test_eof
-	_test_eof271:
-		cs = 271
-		goto _test_eof
-	_test_eof272:
-		cs = 272
-		goto _test_eof
-	_test_eof273:
-		cs = 273
-		goto _test_eof
-	_test_eof274:
-		cs = 274
-		goto _test_eof
-	_test_eof275:
-		cs = 275
-		goto _test_eof
-	_test_eof276:
-		cs = 276
-		goto _test_eof
-	_test_eof277:
-		cs = 277
-		goto _test_eof
-	_test_eof278:
-		cs = 278
-		goto _test_eof
-	_test_eof279:
-		cs = 279
-		goto _test_eof
-	_test_eof280:
-		cs = 280
-		goto _test_eof
-	_test_eof281:
-		cs = 281
-		goto _test_eof
-	_test_eof282:
-		cs = 282
-		goto _test_eof
-	_test_eof283:
-		cs = 283
-		goto _test_eof
-	_test_eof284:
-		cs = 284
-		goto _test_eof
-	_test_eof285:
-		cs = 285
-		goto _test_eof
-	_test_eof286:
-		cs = 286
-		goto _test_eof
-	_test_eof287:
-		cs = 287
-		goto _test_eof
-	_test_eof288:
-		cs = 288
-		goto _test_eof
 
 	_test_eof:
 		{
@@ -7625,7 +7113,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 
 				return p, stack, errInvalidObject
 
-			case 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185:
+			case 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175:
 				err = errUnexpectedEOF
 				{
 					p++
@@ -7638,7 +7126,7 @@ func handleObjectValues(data []byte, handler ObjectValueHandler, stack []int) (i
 					cs = 0
 					goto _out
 				}
-			case 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288:
+			case 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268:
 				err = errUnexpectedEOF
 				{
 					p++

--- a/skip_machine.rl
+++ b/skip_machine.rl
@@ -5,7 +5,15 @@ machine skipper;
 
 include common "common.rl";
 
-skip_json_value = (json_simple_value
+skip_json_number = json_int
+  (
+    '.' @{ p, err = skipFloatDec(data, p+1, pe) }
+    |
+    [eE] @{ p, err = skipFloatExp(data, p+1, pe)}
+  )?
+;
+
+skip_json_value = (json_bool |  json_null | json_string | skip_json_number
   | '['@{fcall skip_array;}
   | '{'@{fcall skip_object;}
   );

--- a/skip_machine.rl.go
+++ b/skip_machine.rl.go
@@ -1743,11 +1743,11 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	var err error
 
 	const skipValue_start int = 1
-	const skipValue_first_final int = 206
+	const skipValue_first_final int = 183
 	const skipValue_error int = 0
 
-	const skipValue_en_skip_array int = 26
-	const skipValue_en_skip_object int = 103
+	const skipValue_en_skip_array int = 23
+	const skipValue_en_skip_object int = 90
 	const skipValue_en_main int = 1
 
 	{
@@ -1773,8 +1773,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st3
 		case 4:
 			goto st4
-		case 206:
-			goto st206
+		case 183:
+			goto st183
 		case 5:
 			goto st5
 		case 6:
@@ -1791,56 +1791,52 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st11
 		case 12:
 			goto st12
-		case 207:
-			goto st207
+		case 184:
+			goto st184
+		case 185:
+			goto st185
+		case 186:
+			goto st186
+		case 187:
+			goto st187
+		case 188:
+			goto st188
+		case 189:
+			goto st189
 		case 13:
 			goto st13
-		case 208:
-			goto st208
-		case 209:
-			goto st209
 		case 14:
 			goto st14
 		case 15:
 			goto st15
-		case 210:
-			goto st210
-		case 211:
-			goto st211
-		case 212:
-			goto st212
-		case 213:
-			goto st213
-		case 214:
-			goto st214
 		case 16:
 			goto st16
+		case 190:
+			goto st190
 		case 17:
 			goto st17
 		case 18:
 			goto st18
 		case 19:
 			goto st19
-		case 215:
-			goto st215
+		case 191:
+			goto st191
 		case 20:
 			goto st20
 		case 21:
 			goto st21
 		case 22:
 			goto st22
-		case 216:
-			goto st216
+		case 192:
+			goto st192
+		case 193:
+			goto st193
 		case 23:
 			goto st23
 		case 24:
 			goto st24
 		case 25:
 			goto st25
-		case 217:
-			goto st217
-		case 218:
-			goto st218
 		case 26:
 			goto st26
 		case 27:
@@ -1857,14 +1853,14 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st32
 		case 33:
 			goto st33
+		case 194:
+			goto st194
 		case 34:
 			goto st34
 		case 35:
 			goto st35
 		case 36:
 			goto st36
-		case 219:
-			goto st219
 		case 37:
 			goto st37
 		case 38:
@@ -2017,6 +2013,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st111
 		case 112:
 			goto st112
+		case 195:
+			goto st195
 		case 113:
 			goto st113
 		case 114:
@@ -2043,8 +2041,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st124
 		case 125:
 			goto st125
-		case 220:
-			goto st220
 		case 126:
 			goto st126
 		case 127:
@@ -2159,52 +2155,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st181
 		case 182:
 			goto st182
-		case 183:
-			goto st183
-		case 184:
-			goto st184
-		case 185:
-			goto st185
-		case 186:
-			goto st186
-		case 187:
-			goto st187
-		case 188:
-			goto st188
-		case 189:
-			goto st189
-		case 190:
-			goto st190
-		case 191:
-			goto st191
-		case 192:
-			goto st192
-		case 193:
-			goto st193
-		case 194:
-			goto st194
-		case 195:
-			goto st195
-		case 196:
-			goto st196
-		case 197:
-			goto st197
-		case 198:
-			goto st198
-		case 199:
-			goto st199
-		case 200:
-			goto st200
-		case 201:
-			goto st201
-		case 202:
-			goto st202
-		case 203:
-			goto st203
-		case 204:
-			goto st204
-		case 205:
-			goto st205
 		}
 
 		if p++; p == pe {
@@ -2222,8 +2172,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_3
 		case 4:
 			goto st_case_4
-		case 206:
-			goto st_case_206
+		case 183:
+			goto st_case_183
 		case 5:
 			goto st_case_5
 		case 6:
@@ -2240,56 +2190,52 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_11
 		case 12:
 			goto st_case_12
-		case 207:
-			goto st_case_207
+		case 184:
+			goto st_case_184
+		case 185:
+			goto st_case_185
+		case 186:
+			goto st_case_186
+		case 187:
+			goto st_case_187
+		case 188:
+			goto st_case_188
+		case 189:
+			goto st_case_189
 		case 13:
 			goto st_case_13
-		case 208:
-			goto st_case_208
-		case 209:
-			goto st_case_209
 		case 14:
 			goto st_case_14
 		case 15:
 			goto st_case_15
-		case 210:
-			goto st_case_210
-		case 211:
-			goto st_case_211
-		case 212:
-			goto st_case_212
-		case 213:
-			goto st_case_213
-		case 214:
-			goto st_case_214
 		case 16:
 			goto st_case_16
+		case 190:
+			goto st_case_190
 		case 17:
 			goto st_case_17
 		case 18:
 			goto st_case_18
 		case 19:
 			goto st_case_19
-		case 215:
-			goto st_case_215
+		case 191:
+			goto st_case_191
 		case 20:
 			goto st_case_20
 		case 21:
 			goto st_case_21
 		case 22:
 			goto st_case_22
-		case 216:
-			goto st_case_216
+		case 192:
+			goto st_case_192
+		case 193:
+			goto st_case_193
 		case 23:
 			goto st_case_23
 		case 24:
 			goto st_case_24
 		case 25:
 			goto st_case_25
-		case 217:
-			goto st_case_217
-		case 218:
-			goto st_case_218
 		case 26:
 			goto st_case_26
 		case 27:
@@ -2306,14 +2252,14 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_32
 		case 33:
 			goto st_case_33
+		case 194:
+			goto st_case_194
 		case 34:
 			goto st_case_34
 		case 35:
 			goto st_case_35
 		case 36:
 			goto st_case_36
-		case 219:
-			goto st_case_219
 		case 37:
 			goto st_case_37
 		case 38:
@@ -2466,6 +2412,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_111
 		case 112:
 			goto st_case_112
+		case 195:
+			goto st_case_195
 		case 113:
 			goto st_case_113
 		case 114:
@@ -2492,8 +2440,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_124
 		case 125:
 			goto st_case_125
-		case 220:
-			goto st_case_220
 		case 126:
 			goto st_case_126
 		case 127:
@@ -2608,52 +2554,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto st_case_181
 		case 182:
 			goto st_case_182
-		case 183:
-			goto st_case_183
-		case 184:
-			goto st_case_184
-		case 185:
-			goto st_case_185
-		case 186:
-			goto st_case_186
-		case 187:
-			goto st_case_187
-		case 188:
-			goto st_case_188
-		case 189:
-			goto st_case_189
-		case 190:
-			goto st_case_190
-		case 191:
-			goto st_case_191
-		case 192:
-			goto st_case_192
-		case 193:
-			goto st_case_193
-		case 194:
-			goto st_case_194
-		case 195:
-			goto st_case_195
-		case 196:
-			goto st_case_196
-		case 197:
-			goto st_case_197
-		case 198:
-			goto st_case_198
-		case 199:
-			goto st_case_199
-		case 200:
-			goto st_case_200
-		case 201:
-			goto st_case_201
-		case 202:
-			goto st_case_202
-		case 203:
-			goto st_case_203
-		case 204:
-			goto st_case_204
-		case 205:
-			goto st_case_205
 		}
 		goto st_out
 	st1:
@@ -2671,22 +2571,22 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		case 45:
 			goto st12
 		case 48:
-			goto st207
+			goto st184
 		case 91:
 			goto tr6
 		case 102:
-			goto st16
+			goto st13
 		case 110:
-			goto st20
+			goto st17
 		case 116:
-			goto st23
+			goto st20
 		case 123:
 			goto tr10
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st212
+				goto st187
 			}
 		case data[p] >= 9:
 			goto st2
@@ -2697,7 +2597,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		return p, stack, errNoValidToken
 
 		goto st0
-	tr33:
+	tr30:
 		err = errInvalidArray
 		{
 			p++
@@ -2705,7 +2605,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto _out
 		}
 		goto st0
-	tr111:
+	tr98:
 		err = errInvalidObject
 		{
 			p++
@@ -2732,22 +2632,22 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		case 45:
 			goto st12
 		case 48:
-			goto st207
+			goto st184
 		case 91:
 			goto tr6
 		case 102:
-			goto st16
+			goto st13
 		case 110:
-			goto st20
+			goto st17
 		case 116:
-			goto st23
+			goto st20
 		case 123:
 			goto tr10
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st212
+				goto st187
 			}
 		case data[p] >= 9:
 			goto st2
@@ -2760,7 +2660,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_3:
 		switch data[p] {
 		case 34:
-			goto st206
+			goto st183
 		case 92:
 			goto st5
 		}
@@ -2775,7 +2675,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_4:
 		switch data[p] {
 		case 34:
-			goto st206
+			goto st183
 		case 92:
 			goto st5
 		}
@@ -2783,11 +2683,11 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto tr0
 		}
 		goto st4
-	st206:
+	st183:
 		if p++; p == pe {
-			goto _test_eof206
+			goto _test_eof183
 		}
-	st_case_206:
+	st_case_183:
 		goto st0
 	st5:
 		if p++; p == pe {
@@ -2822,7 +2722,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_6:
 		switch data[p] {
 		case 34:
-			goto st206
+			goto st183
 		case 92:
 			goto st5
 		}
@@ -2909,7 +2809,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_11:
 		switch data[p] {
 		case 34:
-			goto st206
+			goto st183
 		case 92:
 			goto st5
 		}
@@ -2923,139 +2823,76 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		}
 	st_case_12:
 		if data[p] == 48 {
-			goto st207
+			goto st184
 		}
 		if 49 <= data[p] && data[p] <= 57 {
-			goto st212
+			goto st187
 		}
 		goto tr0
-	st207:
+	st184:
 		if p++; p == pe {
-			goto _test_eof207
+			goto _test_eof184
 		}
-	st_case_207:
+	st_case_184:
 		switch data[p] {
 		case 46:
-			goto st13
+			goto tr193
 		case 69:
-			goto st14
+			goto tr194
 		case 101:
-			goto st14
+			goto tr194
 		}
 		goto st0
-	st13:
+	tr193:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st185
+	st185:
 		if p++; p == pe {
-			goto _test_eof13
+			goto _test_eof185
 		}
-	st_case_13:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st208
-		}
-		goto tr0
-	st208:
-		if p++; p == pe {
-			goto _test_eof208
-		}
-	st_case_208:
-		switch data[p] {
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st209
-		}
+	st_case_185:
 		goto st0
-	st209:
+	tr194:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st186
+	st186:
 		if p++; p == pe {
-			goto _test_eof209
+			goto _test_eof186
 		}
-	st_case_209:
-		switch data[p] {
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st209
-		}
+	st_case_186:
 		goto st0
-	st14:
+	st187:
 		if p++; p == pe {
-			goto _test_eof14
+			goto _test_eof187
 		}
-	st_case_14:
-		switch data[p] {
-		case 43:
-			goto st15
-		case 45:
-			goto st15
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st210
-		}
-		goto tr0
-	st15:
-		if p++; p == pe {
-			goto _test_eof15
-		}
-	st_case_15:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st210
-		}
-		goto tr0
-	st210:
-		if p++; p == pe {
-			goto _test_eof210
-		}
-	st_case_210:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st211
-		}
-		goto st0
-	st211:
-		if p++; p == pe {
-			goto _test_eof211
-		}
-	st_case_211:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st211
-		}
-		goto st0
-	st212:
-		if p++; p == pe {
-			goto _test_eof212
-		}
-	st_case_212:
+	st_case_187:
 		switch data[p] {
 		case 46:
-			goto st13
+			goto tr193
 		case 69:
-			goto st14
+			goto tr194
 		case 101:
-			goto st14
+			goto tr194
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto st213
+			goto st188
 		}
 		goto st0
-	st213:
+	st188:
 		if p++; p == pe {
-			goto _test_eof213
+			goto _test_eof188
 		}
-	st_case_213:
+	st_case_188:
 		switch data[p] {
 		case 46:
-			goto st13
+			goto tr193
 		case 69:
-			goto st14
+			goto tr194
 		case 101:
-			goto st14
+			goto tr194
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto st213
+			goto st188
 		}
 		goto st0
 	tr6:
@@ -3072,33 +2909,66 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 214
+				stack[top] = 189
 				top++
-				goto st26
+				goto st23
 			}
 		}
-		goto st214
-	st214:
+		goto st189
+	st189:
 		if p++; p == pe {
-			goto _test_eof214
+			goto _test_eof189
 		}
-	st_case_214:
+	st_case_189:
 		goto st0
+	st13:
+		if p++; p == pe {
+			goto _test_eof13
+		}
+	st_case_13:
+		if data[p] == 97 {
+			goto st14
+		}
+		goto tr0
+	st14:
+		if p++; p == pe {
+			goto _test_eof14
+		}
+	st_case_14:
+		if data[p] == 108 {
+			goto st15
+		}
+		goto tr0
+	st15:
+		if p++; p == pe {
+			goto _test_eof15
+		}
+	st_case_15:
+		if data[p] == 115 {
+			goto st16
+		}
+		goto tr0
 	st16:
 		if p++; p == pe {
 			goto _test_eof16
 		}
 	st_case_16:
-		if data[p] == 97 {
-			goto st17
+		if data[p] == 101 {
+			goto st190
 		}
 		goto tr0
+	st190:
+		if p++; p == pe {
+			goto _test_eof190
+		}
+	st_case_190:
+		goto st0
 	st17:
 		if p++; p == pe {
 			goto _test_eof17
 		}
 	st_case_17:
-		if data[p] == 108 {
+		if data[p] == 117 {
 			goto st18
 		}
 		goto tr0
@@ -3107,7 +2977,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto _test_eof18
 		}
 	st_case_18:
-		if data[p] == 115 {
+		if data[p] == 108 {
 			goto st19
 		}
 		goto tr0
@@ -3116,22 +2986,22 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto _test_eof19
 		}
 	st_case_19:
-		if data[p] == 101 {
-			goto st215
+		if data[p] == 108 {
+			goto st191
 		}
 		goto tr0
-	st215:
+	st191:
 		if p++; p == pe {
-			goto _test_eof215
+			goto _test_eof191
 		}
-	st_case_215:
+	st_case_191:
 		goto st0
 	st20:
 		if p++; p == pe {
 			goto _test_eof20
 		}
 	st_case_20:
-		if data[p] == 117 {
+		if data[p] == 114 {
 			goto st21
 		}
 		goto tr0
@@ -3140,7 +3010,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto _test_eof21
 		}
 	st_case_21:
-		if data[p] == 108 {
+		if data[p] == 117 {
 			goto st22
 		}
 		goto tr0
@@ -3149,48 +3019,15 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 			goto _test_eof22
 		}
 	st_case_22:
-		if data[p] == 108 {
-			goto st216
-		}
-		goto tr0
-	st216:
-		if p++; p == pe {
-			goto _test_eof216
-		}
-	st_case_216:
-		goto st0
-	st23:
-		if p++; p == pe {
-			goto _test_eof23
-		}
-	st_case_23:
-		if data[p] == 114 {
-			goto st24
-		}
-		goto tr0
-	st24:
-		if p++; p == pe {
-			goto _test_eof24
-		}
-	st_case_24:
-		if data[p] == 117 {
-			goto st25
-		}
-		goto tr0
-	st25:
-		if p++; p == pe {
-			goto _test_eof25
-		}
-	st_case_25:
 		if data[p] == 101 {
-			goto st217
+			goto st192
 		}
 		goto tr0
-	st217:
+	st192:
 		if p++; p == pe {
-			goto _test_eof217
+			goto _test_eof192
 		}
-	st_case_217:
+	st_case_192:
 		goto st0
 	tr10:
 		{
@@ -3206,56 +3043,124 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 218
+				stack[top] = 193
 				top++
-				goto st103
+				goto st90
 			}
 		}
-		goto st218
-	st218:
+		goto st193
+	st193:
 		if p++; p == pe {
-			goto _test_eof218
+			goto _test_eof193
 		}
-	st_case_218:
+	st_case_193:
 		goto st0
+	st23:
+		if p++; p == pe {
+			goto _test_eof23
+		}
+	st_case_23:
+		switch data[p] {
+		case 13:
+			goto st24
+		case 32:
+			goto st24
+		case 34:
+			goto st25
+		case 45:
+			goto st69
+		case 48:
+			goto st70
+		case 91:
+			goto tr36
+		case 93:
+			goto tr37
+		case 102:
+			goto st76
+		case 110:
+			goto st81
+		case 116:
+			goto st85
+		case 123:
+			goto tr41
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st73
+			}
+		case data[p] >= 9:
+			goto st24
+		}
+		goto tr30
+	st24:
+		if p++; p == pe {
+			goto _test_eof24
+		}
+	st_case_24:
+		switch data[p] {
+		case 13:
+			goto st24
+		case 32:
+			goto st24
+		case 34:
+			goto st25
+		case 45:
+			goto st69
+		case 48:
+			goto st70
+		case 91:
+			goto tr36
+		case 93:
+			goto tr37
+		case 102:
+			goto st76
+		case 110:
+			goto st81
+		case 116:
+			goto st85
+		case 123:
+			goto tr41
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st73
+			}
+		case data[p] >= 9:
+			goto st24
+		}
+		goto tr30
+	st25:
+		if p++; p == pe {
+			goto _test_eof25
+		}
+	st_case_25:
+		switch data[p] {
+		case 34:
+			goto st27
+		case 92:
+			goto st62
+		}
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st26
 	st26:
 		if p++; p == pe {
 			goto _test_eof26
 		}
 	st_case_26:
 		switch data[p] {
-		case 13:
-			goto st27
-		case 32:
-			goto st27
 		case 34:
-			goto st28
-		case 45:
-			goto st77
-		case 48:
-			goto st78
-		case 91:
-			goto tr39
-		case 93:
-			goto tr40
-		case 102:
-			goto st89
-		case 110:
-			goto st94
-		case 116:
-			goto st98
-		case 123:
-			goto tr44
-		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st86
-			}
-		case data[p] >= 9:
 			goto st27
+		case 92:
+			goto st62
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st26
 	st27:
 		if p++; p == pe {
 			goto _test_eof27
@@ -3263,67 +3168,73 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_27:
 		switch data[p] {
 		case 13:
-			goto st27
-		case 32:
-			goto st27
-		case 34:
 			goto st28
-		case 45:
-			goto st77
-		case 48:
-			goto st78
-		case 91:
-			goto tr39
+		case 32:
+			goto st28
+		case 44:
+			goto st29
 		case 93:
-			goto tr40
-		case 102:
-			goto st89
-		case 110:
-			goto st94
-		case 116:
-			goto st98
-		case 123:
-			goto tr44
+			goto tr37
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st86
-			}
-		case data[p] >= 9:
-			goto st27
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st28:
 		if p++; p == pe {
 			goto _test_eof28
 		}
 	st_case_28:
 		switch data[p] {
-		case 34:
-			goto st30
-		case 92:
-			goto st70
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		if data[p] <= 31 {
-			goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto st29
+		goto tr30
 	st29:
 		if p++; p == pe {
 			goto _test_eof29
 		}
 	st_case_29:
 		switch data[p] {
-		case 34:
+		case 13:
 			goto st30
-		case 92:
-			goto st70
+		case 32:
+			goto st30
+		case 34:
+			goto st31
+		case 45:
+			goto st41
+		case 48:
+			goto st42
+		case 91:
+			goto tr52
+		case 102:
+			goto st48
+		case 110:
+			goto st53
+		case 116:
+			goto st57
+		case 123:
+			goto tr56
 		}
-		if data[p] <= 31 {
-			goto tr33
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st45
+			}
+		case data[p] >= 9:
+			goto st30
 		}
-		goto st29
+		goto tr30
 	st30:
 		if p++; p == pe {
 			goto _test_eof30
@@ -3331,73 +3242,65 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_30:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st30
 		case 32:
+			goto st30
+		case 34:
 			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		case 45:
+			goto st41
+		case 48:
+			goto st42
+		case 91:
+			goto tr52
+		case 102:
+			goto st48
+		case 110:
+			goto st53
+		case 116:
+			goto st57
+		case 123:
+			goto tr56
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st45
+			}
+		case data[p] >= 9:
+			goto st30
 		}
-		goto tr33
+		goto tr30
 	st31:
 		if p++; p == pe {
 			goto _test_eof31
 		}
 	st_case_31:
 		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		case 34:
+			goto st33
+		case 92:
+			goto st34
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		if data[p] <= 31 {
+			goto tr30
 		}
-		goto tr33
+		goto st32
 	st32:
 		if p++; p == pe {
 			goto _test_eof32
 		}
 	st_case_32:
 		switch data[p] {
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 34:
-			goto st34
-		case 45:
-			goto st44
-		case 48:
-			goto st45
-		case 91:
-			goto tr55
-		case 102:
-			goto st56
-		case 110:
-			goto st61
-		case 116:
-			goto st65
-		case 123:
-			goto tr59
-		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st53
-			}
-		case data[p] >= 9:
 			goto st33
+		case 92:
+			goto st34
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st32
 	st33:
 		if p++; p == pe {
 			goto _test_eof33
@@ -3405,35 +3308,31 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_33:
 		switch data[p] {
 		case 13:
-			goto st33
+			goto st28
 		case 32:
-			goto st33
-		case 34:
-			goto st34
-		case 45:
-			goto st44
-		case 48:
-			goto st45
-		case 91:
-			goto tr55
-		case 102:
-			goto st56
-		case 110:
-			goto st61
-		case 116:
-			goto st65
-		case 123:
-			goto tr59
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st53
-			}
-		case data[p] >= 9:
-			goto st33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto tr33
+		goto tr30
+	tr37:
+		{
+			top--
+			cs = stack[top]
+			goto _again
+		}
+		goto st194
+	st194:
+		if p++; p == pe {
+			goto _test_eof194
+		}
+	st_case_194:
+		goto st0
 	st34:
 		if p++; p == pe {
 			goto _test_eof34
@@ -3441,14 +3340,25 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_34:
 		switch data[p] {
 		case 34:
-			goto st36
+			goto st35
+		case 47:
+			goto st35
 		case 92:
-			goto st37
+			goto st35
+		case 98:
+			goto st35
+		case 102:
+			goto st35
+		case 110:
+			goto st35
+		case 114:
+			goto st35
+		case 116:
+			goto st35
+		case 117:
+			goto st36
 		}
-		if data[p] <= 31 {
-			goto tr33
-		}
-		goto st35
+		goto tr30
 	st35:
 		if p++; p == pe {
 			goto _test_eof35
@@ -3456,87 +3366,68 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_35:
 		switch data[p] {
 		case 34:
-			goto st36
+			goto st33
 		case 92:
-			goto st37
+			goto st34
 		}
 		if data[p] <= 31 {
-			goto tr33
+			goto tr30
 		}
-		goto st35
+		goto st32
 	st36:
 		if p++; p == pe {
 			goto _test_eof36
 		}
 	st_case_36:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st37
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st37
+			}
+		default:
+			goto st37
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
-		}
-		goto tr33
-	tr40:
-		{
-			top--
-			cs = stack[top]
-			goto _again
-		}
-		goto st219
-	st219:
-		if p++; p == pe {
-			goto _test_eof219
-		}
-	st_case_219:
-		goto st0
+		goto tr30
 	st37:
 		if p++; p == pe {
 			goto _test_eof37
 		}
 	st_case_37:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st38
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st38
+			}
+		default:
 			goto st38
-		case 47:
-			goto st38
-		case 92:
-			goto st38
-		case 98:
-			goto st38
-		case 102:
-			goto st38
-		case 110:
-			goto st38
-		case 114:
-			goto st38
-		case 116:
-			goto st38
-		case 117:
-			goto st39
 		}
-		goto tr33
+		goto tr30
 	st38:
 		if p++; p == pe {
 			goto _test_eof38
 		}
 	st_case_38:
-		switch data[p] {
-		case 34:
-			goto st36
-		case 92:
-			goto st37
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st39
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st39
+			}
+		default:
+			goto st39
 		}
-		if data[p] <= 31 {
-			goto tr33
-		}
-		goto st35
+		goto tr30
 	st39:
 		if p++; p == pe {
 			goto _test_eof39
@@ -3554,88 +3445,103 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		default:
 			goto st40
 		}
-		goto tr33
+		goto tr30
 	st40:
 		if p++; p == pe {
 			goto _test_eof40
 		}
 	st_case_40:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st41
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st41
-			}
-		default:
-			goto st41
+		switch data[p] {
+		case 34:
+			goto st33
+		case 92:
+			goto st34
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st32
 	st41:
 		if p++; p == pe {
 			goto _test_eof41
 		}
 	st_case_41:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st42
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st42
-			}
-		default:
+		if data[p] == 48 {
 			goto st42
 		}
-		goto tr33
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st45
+		}
+		goto tr30
 	st42:
 		if p++; p == pe {
 			goto _test_eof42
 		}
 	st_case_42:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st43
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st43
-			}
-		default:
-			goto st43
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 46:
+			goto tr66
+		case 69:
+			goto tr67
+		case 93:
+			goto tr37
+		case 101:
+			goto tr67
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
+	tr66:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st43
 	st43:
 		if p++; p == pe {
 			goto _test_eof43
 		}
 	st_case_43:
 		switch data[p] {
-		case 34:
-			goto st36
-		case 92:
-			goto st37
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		if data[p] <= 31 {
-			goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto st35
+		goto tr30
+	tr67:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st44
 	st44:
 		if p++; p == pe {
 			goto _test_eof44
 		}
 	st_case_44:
-		if data[p] == 48 {
-			goto st45
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st53
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st45:
 		if p++; p == pe {
 			goto _test_eof45
@@ -3643,222 +3549,60 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_45:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
+			goto st29
 		case 46:
-			goto st46
+			goto tr66
 		case 69:
-			goto st49
+			goto tr67
 		case 93:
-			goto tr40
+			goto tr37
 		case 101:
-			goto st49
+			goto tr67
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st46
+			}
+		case data[p] >= 9:
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st46:
 		if p++; p == pe {
 			goto _test_eof46
 		}
 	st_case_46:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st47
-		}
-		goto tr33
-	st47:
-		if p++; p == pe {
-			goto _test_eof47
-		}
-	st_case_47:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
-		case 69:
-			goto st49
-		case 93:
-			goto tr40
-		case 101:
-			goto st49
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st48
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	st48:
-		if p++; p == pe {
-			goto _test_eof48
-		}
-	st_case_48:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 69:
-			goto st49
-		case 93:
-			goto tr40
-		case 101:
-			goto st49
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st48
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	st49:
-		if p++; p == pe {
-			goto _test_eof49
-		}
-	st_case_49:
-		switch data[p] {
-		case 43:
-			goto st50
-		case 45:
-			goto st50
-		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st51
-		}
-		goto tr33
-	st50:
-		if p++; p == pe {
-			goto _test_eof50
-		}
-	st_case_50:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st51
-		}
-		goto tr33
-	st51:
-		if p++; p == pe {
-			goto _test_eof51
-		}
-	st_case_51:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st52
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	st52:
-		if p++; p == pe {
-			goto _test_eof52
-		}
-	st_case_52:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st52
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	st53:
-		if p++; p == pe {
-			goto _test_eof53
-		}
-	st_case_53:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
+			goto st29
 		case 46:
-			goto st46
+			goto tr66
 		case 69:
-			goto st49
+			goto tr67
 		case 93:
-			goto tr40
+			goto tr37
 		case 101:
-			goto st49
+			goto tr67
 		}
 		switch {
 		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st54
+				goto st46
 			}
 		case data[p] >= 9:
-			goto st31
+			goto st28
 		}
-		goto tr33
-	st54:
-		if p++; p == pe {
-			goto _test_eof54
-		}
-	st_case_54:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 46:
-			goto st46
-		case 69:
-			goto st49
-		case 93:
-			goto tr40
-		case 101:
-			goto st49
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st54
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	tr55:
+		goto tr30
+	tr52:
 		{
 			if top == skipMaxDepth {
 				err = errMaxDepth
@@ -3872,58 +3616,150 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 55
+				stack[top] = 47
 				top++
-				goto st26
+				goto st23
 			}
 		}
-		goto st55
+		goto st47
+	st47:
+		if p++; p == pe {
+			goto _test_eof47
+		}
+	st_case_47:
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
+	st48:
+		if p++; p == pe {
+			goto _test_eof48
+		}
+	st_case_48:
+		if data[p] == 97 {
+			goto st49
+		}
+		goto tr30
+	st49:
+		if p++; p == pe {
+			goto _test_eof49
+		}
+	st_case_49:
+		if data[p] == 108 {
+			goto st50
+		}
+		goto tr30
+	st50:
+		if p++; p == pe {
+			goto _test_eof50
+		}
+	st_case_50:
+		if data[p] == 115 {
+			goto st51
+		}
+		goto tr30
+	st51:
+		if p++; p == pe {
+			goto _test_eof51
+		}
+	st_case_51:
+		if data[p] == 101 {
+			goto st52
+		}
+		goto tr30
+	st52:
+		if p++; p == pe {
+			goto _test_eof52
+		}
+	st_case_52:
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
+	st53:
+		if p++; p == pe {
+			goto _test_eof53
+		}
+	st_case_53:
+		if data[p] == 117 {
+			goto st54
+		}
+		goto tr30
+	st54:
+		if p++; p == pe {
+			goto _test_eof54
+		}
+	st_case_54:
+		if data[p] == 108 {
+			goto st55
+		}
+		goto tr30
 	st55:
 		if p++; p == pe {
 			goto _test_eof55
 		}
 	st_case_55:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		if data[p] == 108 {
+			goto st56
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
-		}
-		goto tr33
+		goto tr30
 	st56:
 		if p++; p == pe {
 			goto _test_eof56
 		}
 	st_case_56:
-		if data[p] == 97 {
-			goto st57
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
 	st57:
 		if p++; p == pe {
 			goto _test_eof57
 		}
 	st_case_57:
-		if data[p] == 108 {
+		if data[p] == 114 {
 			goto st58
 		}
-		goto tr33
+		goto tr30
 	st58:
 		if p++; p == pe {
 			goto _test_eof58
 		}
 	st_case_58:
-		if data[p] == 115 {
+		if data[p] == 117 {
 			goto st59
 		}
-		goto tr33
+		goto tr30
 	st59:
 		if p++; p == pe {
 			goto _test_eof59
@@ -3932,7 +3768,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		if data[p] == 101 {
 			goto st60
 		}
-		goto tr33
+		goto tr30
 	st60:
 		if p++; p == pe {
 			goto _test_eof60
@@ -3940,111 +3776,19 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_60:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
+			goto st29
 		case 93:
-			goto tr40
+			goto tr37
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+			goto st28
 		}
-		goto tr33
-	st61:
-		if p++; p == pe {
-			goto _test_eof61
-		}
-	st_case_61:
-		if data[p] == 117 {
-			goto st62
-		}
-		goto tr33
-	st62:
-		if p++; p == pe {
-			goto _test_eof62
-		}
-	st_case_62:
-		if data[p] == 108 {
-			goto st63
-		}
-		goto tr33
-	st63:
-		if p++; p == pe {
-			goto _test_eof63
-		}
-	st_case_63:
-		if data[p] == 108 {
-			goto st64
-		}
-		goto tr33
-	st64:
-		if p++; p == pe {
-			goto _test_eof64
-		}
-	st_case_64:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
-		}
-		goto tr33
-	st65:
-		if p++; p == pe {
-			goto _test_eof65
-		}
-	st_case_65:
-		if data[p] == 114 {
-			goto st66
-		}
-		goto tr33
-	st66:
-		if p++; p == pe {
-			goto _test_eof66
-		}
-	st_case_66:
-		if data[p] == 117 {
-			goto st67
-		}
-		goto tr33
-	st67:
-		if p++; p == pe {
-			goto _test_eof67
-		}
-	st_case_67:
-		if data[p] == 101 {
-			goto st68
-		}
-		goto tr33
-	st68:
-		if p++; p == pe {
-			goto _test_eof68
-		}
-	st_case_68:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
-		}
-		goto tr33
-	tr59:
+		goto tr30
+	tr56:
 		{
 			if top == skipMaxDepth {
 				err = errMaxDepth
@@ -4058,205 +3802,375 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 				stack = append(stack, make([]int, 1+top-len(stack))...)
 			}
 			{
-				stack[top] = 69
+				stack[top] = 61
 				top++
-				goto st103
+				goto st90
 			}
 		}
-		goto st69
+		goto st61
+	st61:
+		if p++; p == pe {
+			goto _test_eof61
+		}
+	st_case_61:
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
+		}
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
+	st62:
+		if p++; p == pe {
+			goto _test_eof62
+		}
+	st_case_62:
+		switch data[p] {
+		case 34:
+			goto st63
+		case 47:
+			goto st63
+		case 92:
+			goto st63
+		case 98:
+			goto st63
+		case 102:
+			goto st63
+		case 110:
+			goto st63
+		case 114:
+			goto st63
+		case 116:
+			goto st63
+		case 117:
+			goto st64
+		}
+		goto tr30
+	st63:
+		if p++; p == pe {
+			goto _test_eof63
+		}
+	st_case_63:
+		switch data[p] {
+		case 34:
+			goto st27
+		case 92:
+			goto st62
+		}
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st26
+	st64:
+		if p++; p == pe {
+			goto _test_eof64
+		}
+	st_case_64:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st65
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st65
+			}
+		default:
+			goto st65
+		}
+		goto tr30
+	st65:
+		if p++; p == pe {
+			goto _test_eof65
+		}
+	st_case_65:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st66
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st66
+			}
+		default:
+			goto st66
+		}
+		goto tr30
+	st66:
+		if p++; p == pe {
+			goto _test_eof66
+		}
+	st_case_66:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st67
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st67
+			}
+		default:
+			goto st67
+		}
+		goto tr30
+	st67:
+		if p++; p == pe {
+			goto _test_eof67
+		}
+	st_case_67:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st68
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st68
+			}
+		default:
+			goto st68
+		}
+		goto tr30
+	st68:
+		if p++; p == pe {
+			goto _test_eof68
+		}
+	st_case_68:
+		switch data[p] {
+		case 34:
+			goto st27
+		case 92:
+			goto st62
+		}
+		if data[p] <= 31 {
+			goto tr30
+		}
+		goto st26
 	st69:
 		if p++; p == pe {
 			goto _test_eof69
 		}
 	st_case_69:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		if data[p] == 48 {
+			goto st70
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st73
 		}
-		goto tr33
+		goto tr30
 	st70:
 		if p++; p == pe {
 			goto _test_eof70
 		}
 	st_case_70:
 		switch data[p] {
-		case 34:
-			goto st71
-		case 47:
-			goto st71
-		case 92:
-			goto st71
-		case 98:
-			goto st71
-		case 102:
-			goto st71
-		case 110:
-			goto st71
-		case 114:
-			goto st71
-		case 116:
-			goto st71
-		case 117:
-			goto st72
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 46:
+			goto tr85
+		case 69:
+			goto tr86
+		case 93:
+			goto tr37
+		case 101:
+			goto tr86
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
+	tr85:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st71
 	st71:
 		if p++; p == pe {
 			goto _test_eof71
 		}
 	st_case_71:
 		switch data[p] {
-		case 34:
-			goto st30
-		case 92:
-			goto st70
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		if data[p] <= 31 {
-			goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto st29
+		goto tr30
+	tr86:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st72
 	st72:
 		if p++; p == pe {
 			goto _test_eof72
 		}
 	st_case_72:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st73
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st73
-			}
-		default:
-			goto st73
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
 	st73:
 		if p++; p == pe {
 			goto _test_eof73
 		}
 	st_case_73:
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 46:
+			goto tr85
+		case 69:
+			goto tr86
+		case 93:
+			goto tr37
+		case 101:
+			goto tr86
+		}
 		switch {
-		case data[p] < 65:
+		case data[p] > 10:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st74
 			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st74
-			}
-		default:
-			goto st74
+		case data[p] >= 9:
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st74:
 		if p++; p == pe {
 			goto _test_eof74
 		}
 	st_case_74:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st75
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st75
-			}
-		default:
-			goto st75
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 46:
+			goto tr85
+		case 69:
+			goto tr86
+		case 93:
+			goto tr37
+		case 101:
+			goto tr86
 		}
-		goto tr33
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st74
+			}
+		case data[p] >= 9:
+			goto st28
+		}
+		goto tr30
+	tr36:
+		{
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 75
+				top++
+				goto st23
+			}
+		}
+		goto st75
 	st75:
 		if p++; p == pe {
 			goto _test_eof75
 		}
 	st_case_75:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st76
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st76
-			}
-		default:
-			goto st76
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
 	st76:
 		if p++; p == pe {
 			goto _test_eof76
 		}
 	st_case_76:
-		switch data[p] {
-		case 34:
-			goto st30
-		case 92:
-			goto st70
+		if data[p] == 97 {
+			goto st77
 		}
-		if data[p] <= 31 {
-			goto tr33
-		}
-		goto st29
+		goto tr30
 	st77:
 		if p++; p == pe {
 			goto _test_eof77
 		}
 	st_case_77:
-		if data[p] == 48 {
+		if data[p] == 108 {
 			goto st78
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st86
-		}
-		goto tr33
+		goto tr30
 	st78:
 		if p++; p == pe {
 			goto _test_eof78
 		}
 	st_case_78:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 46:
+		if data[p] == 115 {
 			goto st79
-		case 69:
-			goto st82
-		case 93:
-			goto tr40
-		case 101:
-			goto st82
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
-		}
-		goto tr33
+		goto tr30
 	st79:
 		if p++; p == pe {
 			goto _test_eof79
 		}
 	st_case_79:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 101 {
 			goto st80
 		}
-		goto tr33
+		goto tr30
 	st80:
 		if p++; p == pe {
 			goto _test_eof80
@@ -4264,79 +4178,45 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_80:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
-		case 69:
-			goto st82
+			goto st29
 		case 93:
-			goto tr40
-		case 101:
-			goto st82
+			goto tr37
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st81
-			}
-		case data[p] >= 9:
-			goto st31
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st81:
 		if p++; p == pe {
 			goto _test_eof81
 		}
 	st_case_81:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 69:
-			goto st82
-		case 93:
-			goto tr40
-		case 101:
+		if data[p] == 117 {
 			goto st82
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st81
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
+		goto tr30
 	st82:
 		if p++; p == pe {
 			goto _test_eof82
 		}
 	st_case_82:
-		switch data[p] {
-		case 43:
-			goto st83
-		case 45:
+		if data[p] == 108 {
 			goto st83
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st84
-		}
-		goto tr33
+		goto tr30
 	st83:
 		if p++; p == pe {
 			goto _test_eof83
 		}
 	st_case_83:
-		if 48 <= data[p] && data[p] <= 57 {
+		if data[p] == 108 {
 			goto st84
 		}
-		goto tr33
+		goto tr30
 	st84:
 		if p++; p == pe {
 			goto _test_eof84
@@ -4344,127 +4224,45 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_84:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
+			goto st29
 		case 93:
-			goto tr40
+			goto tr37
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st85
-			}
-		case data[p] >= 9:
-			goto st31
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
 		}
-		goto tr33
+		goto tr30
 	st85:
 		if p++; p == pe {
 			goto _test_eof85
 		}
 	st_case_85:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		if data[p] == 114 {
+			goto st86
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st85
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
+		goto tr30
 	st86:
 		if p++; p == pe {
 			goto _test_eof86
 		}
 	st_case_86:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 46:
-			goto st79
-		case 69:
-			goto st82
-		case 93:
-			goto tr40
-		case 101:
-			goto st82
+		if data[p] == 117 {
+			goto st87
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st87
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
+		goto tr30
 	st87:
 		if p++; p == pe {
 			goto _test_eof87
 		}
 	st_case_87:
-		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 46:
-			goto st79
-		case 69:
-			goto st82
-		case 93:
-			goto tr40
-		case 101:
-			goto st82
+		if data[p] == 101 {
+			goto st88
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st87
-			}
-		case data[p] >= 9:
-			goto st31
-		}
-		goto tr33
-	tr39:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 88
-				top++
-				goto st26
-			}
-		}
-		goto st88
+		goto tr30
 	st88:
 		if p++; p == pe {
 			goto _test_eof88
@@ -4472,100 +4270,195 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_88:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st28
 		case 32:
-			goto st31
+			goto st28
 		case 44:
-			goto st32
+			goto st29
 		case 93:
-			goto tr40
+			goto tr37
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+			goto st28
 		}
-		goto tr33
+		goto tr30
+	tr41:
+		{
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 89
+				top++
+				goto st90
+			}
+		}
+		goto st89
 	st89:
 		if p++; p == pe {
 			goto _test_eof89
 		}
 	st_case_89:
-		if data[p] == 97 {
-			goto st90
+		switch data[p] {
+		case 13:
+			goto st28
+		case 32:
+			goto st28
+		case 44:
+			goto st29
+		case 93:
+			goto tr37
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st28
+		}
+		goto tr30
 	st90:
 		if p++; p == pe {
 			goto _test_eof90
 		}
 	st_case_90:
-		if data[p] == 108 {
+		switch data[p] {
+		case 13:
+			goto st91
+		case 32:
+			goto st91
+		case 34:
+			goto st92
+		case 125:
+			goto tr101
+		}
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st91
 		}
-		goto tr33
+		goto tr98
 	st91:
 		if p++; p == pe {
 			goto _test_eof91
 		}
 	st_case_91:
-		if data[p] == 115 {
+		switch data[p] {
+		case 13:
+			goto st91
+		case 32:
+			goto st91
+		case 34:
 			goto st92
+		case 125:
+			goto tr101
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st91
+		}
+		goto tr98
 	st92:
 		if p++; p == pe {
 			goto _test_eof92
 		}
 	st_case_92:
-		if data[p] == 101 {
-			goto st93
+		switch data[p] {
+		case 34:
+			goto st94
+		case 92:
+			goto st176
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr98
+		}
+		goto st93
 	st93:
 		if p++; p == pe {
 			goto _test_eof93
 		}
 	st_case_93:
 		switch data[p] {
-		case 13:
-			goto st31
-		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+		case 34:
+			goto st94
+		case 92:
+			goto st176
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr33
+		goto st93
 	st94:
 		if p++; p == pe {
 			goto _test_eof94
 		}
 	st_case_94:
-		if data[p] == 117 {
+		switch data[p] {
+		case 13:
+			goto st95
+		case 32:
+			goto st95
+		case 58:
+			goto st96
+		}
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st95
 		}
-		goto tr33
+		goto tr98
 	st95:
 		if p++; p == pe {
 			goto _test_eof95
 		}
 	st_case_95:
-		if data[p] == 108 {
+		switch data[p] {
+		case 13:
+			goto st95
+		case 32:
+			goto st95
+		case 58:
 			goto st96
 		}
-		goto tr33
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st95
+		}
+		goto tr98
 	st96:
 		if p++; p == pe {
 			goto _test_eof96
 		}
 	st_case_96:
-		if data[p] == 108 {
+		switch data[p] {
+		case 13:
+			goto st97
+		case 32:
+			goto st97
+		case 34:
+			goto st98
+		case 45:
+			goto st155
+		case 48:
+			goto st156
+		case 91:
+			goto tr112
+		case 102:
+			goto st162
+		case 110:
+			goto st167
+		case 116:
+			goto st171
+		case 123:
+			goto tr116
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st159
+			}
+		case data[p] >= 9:
 			goto st97
 		}
-		goto tr33
+		goto tr98
 	st97:
 		if p++; p == pe {
 			goto _test_eof97
@@ -4573,45 +4466,84 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_97:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st97
 		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+			goto st97
+		case 34:
+			goto st98
+		case 45:
+			goto st155
+		case 48:
+			goto st156
+		case 91:
+			goto tr112
+		case 102:
+			goto st162
+		case 110:
+			goto st167
+		case 116:
+			goto st171
+		case 123:
+			goto tr116
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st159
+			}
+		case data[p] >= 9:
+			goto st97
 		}
-		goto tr33
+		goto tr98
 	st98:
 		if p++; p == pe {
 			goto _test_eof98
 		}
 	st_case_98:
-		if data[p] == 114 {
-			goto st99
+		switch data[p] {
+		case 34:
+			goto st100
+		case 92:
+			goto st148
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr98
+		}
+		goto st99
 	st99:
 		if p++; p == pe {
 			goto _test_eof99
 		}
 	st_case_99:
-		if data[p] == 117 {
+		switch data[p] {
+		case 34:
 			goto st100
+		case 92:
+			goto st148
 		}
-		goto tr33
+		if data[p] <= 31 {
+			goto tr98
+		}
+		goto st99
 	st100:
 		if p++; p == pe {
 			goto _test_eof100
 		}
 	st_case_100:
-		if data[p] == 101 {
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
+		}
+		if 9 <= data[p] && data[p] <= 10 {
 			goto st101
 		}
-		goto tr33
+		goto tr98
 	st101:
 		if p++; p == pe {
 			goto _test_eof101
@@ -4619,38 +4551,18 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_101:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st101
 		case 32:
-			goto st31
+			goto st101
 		case 44:
-			goto st32
-		case 93:
-			goto tr40
+			goto st102
+		case 125:
+			goto tr101
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+			goto st101
 		}
-		goto tr33
-	tr44:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 102
-				top++
-				goto st103
-			}
-		}
-		goto st102
+		goto tr98
 	st102:
 		if p++; p == pe {
 			goto _test_eof102
@@ -4658,18 +4570,16 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_102:
 		switch data[p] {
 		case 13:
-			goto st31
+			goto st103
 		case 32:
-			goto st31
-		case 44:
-			goto st32
-		case 93:
-			goto tr40
+			goto st103
+		case 34:
+			goto st104
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st31
+			goto st103
 		}
-		goto tr33
+		goto tr98
 	st103:
 		if p++; p == pe {
 			goto _test_eof103
@@ -4677,37 +4587,31 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_103:
 		switch data[p] {
 		case 13:
-			goto st104
+			goto st103
 		case 32:
-			goto st104
+			goto st103
 		case 34:
-			goto st105
-		case 125:
-			goto tr114
+			goto st104
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st104
+			goto st103
 		}
-		goto tr111
+		goto tr98
 	st104:
 		if p++; p == pe {
 			goto _test_eof104
 		}
 	st_case_104:
 		switch data[p] {
-		case 13:
-			goto st104
-		case 32:
-			goto st104
 		case 34:
-			goto st105
-		case 125:
-			goto tr114
+			goto st106
+		case 92:
+			goto st141
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st104
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st105
 	st105:
 		if p++; p == pe {
 			goto _test_eof105
@@ -4715,29 +4619,31 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_105:
 		switch data[p] {
 		case 34:
-			goto st107
+			goto st106
 		case 92:
-			goto st199
+			goto st141
 		}
 		if data[p] <= 31 {
-			goto tr111
+			goto tr98
 		}
-		goto st106
+		goto st105
 	st106:
 		if p++; p == pe {
 			goto _test_eof106
 		}
 	st_case_106:
 		switch data[p] {
-		case 34:
+		case 13:
 			goto st107
-		case 92:
-			goto st199
+		case 32:
+			goto st107
+		case 58:
+			goto st108
 		}
-		if data[p] <= 31 {
-			goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st107
 		}
-		goto st106
+		goto tr98
 	st107:
 		if p++; p == pe {
 			goto _test_eof107
@@ -4745,16 +4651,16 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_107:
 		switch data[p] {
 		case 13:
-			goto st108
+			goto st107
 		case 32:
-			goto st108
+			goto st107
 		case 58:
-			goto st109
+			goto st108
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st108
+			goto st107
 		}
-		goto tr111
+		goto tr98
 	st108:
 		if p++; p == pe {
 			goto _test_eof108
@@ -4762,16 +4668,35 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_108:
 		switch data[p] {
 		case 13:
-			goto st108
+			goto st109
 		case 32:
-			goto st108
-		case 58:
+			goto st109
+		case 34:
+			goto st110
+		case 45:
+			goto st120
+		case 48:
+			goto st121
+		case 91:
+			goto tr134
+		case 102:
+			goto st127
+		case 110:
+			goto st132
+		case 116:
+			goto st136
+		case 123:
+			goto tr138
+		}
+		switch {
+		case data[p] > 10:
+			if 49 <= data[p] && data[p] <= 57 {
+				goto st124
+			}
+		case data[p] >= 9:
 			goto st109
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st108
-		}
-		goto tr111
+		goto tr98
 	st109:
 		if p++; p == pe {
 			goto _test_eof109
@@ -4779,71 +4704,50 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_109:
 		switch data[p] {
 		case 13:
-			goto st110
+			goto st109
 		case 32:
-			goto st110
+			goto st109
 		case 34:
-			goto st111
+			goto st110
 		case 45:
-			goto st173
+			goto st120
 		case 48:
-			goto st174
+			goto st121
 		case 91:
-			goto tr125
+			goto tr134
 		case 102:
-			goto st185
+			goto st127
 		case 110:
-			goto st190
+			goto st132
 		case 116:
-			goto st194
+			goto st136
 		case 123:
-			goto tr129
+			goto tr138
 		}
 		switch {
 		case data[p] > 10:
 			if 49 <= data[p] && data[p] <= 57 {
-				goto st182
+				goto st124
 			}
 		case data[p] >= 9:
-			goto st110
+			goto st109
 		}
-		goto tr111
+		goto tr98
 	st110:
 		if p++; p == pe {
 			goto _test_eof110
 		}
 	st_case_110:
 		switch data[p] {
-		case 13:
-			goto st110
-		case 32:
-			goto st110
 		case 34:
-			goto st111
-		case 45:
-			goto st173
-		case 48:
-			goto st174
-		case 91:
-			goto tr125
-		case 102:
-			goto st185
-		case 110:
-			goto st190
-		case 116:
-			goto st194
-		case 123:
-			goto tr129
+			goto st112
+		case 92:
+			goto st113
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st182
-			}
-		case data[p] >= 9:
-			goto st110
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st111
 	st111:
 		if p++; p == pe {
 			goto _test_eof111
@@ -4851,165 +4755,186 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_111:
 		switch data[p] {
 		case 34:
-			goto st113
+			goto st112
 		case 92:
-			goto st166
+			goto st113
 		}
 		if data[p] <= 31 {
-			goto tr111
+			goto tr98
 		}
-		goto st112
+		goto st111
 	st112:
 		if p++; p == pe {
 			goto _test_eof112
 		}
 	st_case_112:
 		switch data[p] {
-		case 34:
-			goto st113
-		case 92:
-			goto st166
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		if data[p] <= 31 {
-			goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
 		}
-		goto st112
+		goto tr98
+	tr101:
+		{
+			top--
+			cs = stack[top]
+			goto _again
+		}
+		goto st195
+	st195:
+		if p++; p == pe {
+			goto _test_eof195
+		}
+	st_case_195:
+		goto st0
 	st113:
 		if p++; p == pe {
 			goto _test_eof113
 		}
 	st_case_113:
 		switch data[p] {
-		case 13:
+		case 34:
 			goto st114
-		case 32:
+		case 47:
 			goto st114
-		case 44:
+		case 92:
+			goto st114
+		case 98:
+			goto st114
+		case 102:
+			goto st114
+		case 110:
+			goto st114
+		case 114:
+			goto st114
+		case 116:
+			goto st114
+		case 117:
 			goto st115
-		case 125:
-			goto tr114
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st114:
 		if p++; p == pe {
 			goto _test_eof114
 		}
 	st_case_114:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
+		case 34:
+			goto st112
+		case 92:
+			goto st113
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st111
 	st115:
 		if p++; p == pe {
 			goto _test_eof115
 		}
 	st_case_115:
-		switch data[p] {
-		case 13:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st116
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st116
+			}
+		default:
 			goto st116
-		case 32:
-			goto st116
-		case 34:
-			goto st117
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st116
-		}
-		goto tr111
+		goto tr98
 	st116:
 		if p++; p == pe {
 			goto _test_eof116
 		}
 	st_case_116:
-		switch data[p] {
-		case 13:
-			goto st116
-		case 32:
-			goto st116
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st117
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st117
+			}
+		default:
 			goto st117
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st116
-		}
-		goto tr111
+		goto tr98
 	st117:
 		if p++; p == pe {
 			goto _test_eof117
 		}
 	st_case_117:
-		switch data[p] {
-		case 34:
-			goto st119
-		case 92:
-			goto st159
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st118
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st118
+			}
+		default:
+			goto st118
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st118
+		goto tr98
 	st118:
 		if p++; p == pe {
 			goto _test_eof118
 		}
 	st_case_118:
-		switch data[p] {
-		case 34:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st119
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st119
+			}
+		default:
 			goto st119
-		case 92:
-			goto st159
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st118
+		goto tr98
 	st119:
 		if p++; p == pe {
 			goto _test_eof119
 		}
 	st_case_119:
 		switch data[p] {
-		case 13:
-			goto st120
-		case 32:
-			goto st120
-		case 58:
-			goto st121
+		case 34:
+			goto st112
+		case 92:
+			goto st113
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st120
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st111
 	st120:
 		if p++; p == pe {
 			goto _test_eof120
 		}
 	st_case_120:
-		switch data[p] {
-		case 13:
-			goto st120
-		case 32:
-			goto st120
-		case 58:
+		if data[p] == 48 {
 			goto st121
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st120
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st124
 		}
-		goto tr111
+		goto tr98
 	st121:
 		if p++; p == pe {
 			goto _test_eof121
@@ -5017,35 +4942,27 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_121:
 		switch data[p] {
 		case 13:
-			goto st122
+			goto st101
 		case 32:
-			goto st122
-		case 34:
-			goto st123
-		case 45:
-			goto st133
-		case 48:
-			goto st134
-		case 91:
-			goto tr147
-		case 102:
-			goto st145
-		case 110:
-			goto st150
-		case 116:
-			goto st154
-		case 123:
-			goto tr151
+			goto st101
+		case 44:
+			goto st102
+		case 46:
+			goto tr148
+		case 69:
+			goto tr149
+		case 101:
+			goto tr149
+		case 125:
+			goto tr101
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st142
-			}
-		case data[p] >= 9:
-			goto st122
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
 		}
-		goto tr111
+		goto tr98
+	tr148:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st122
 	st122:
 		if p++; p == pe {
 			goto _test_eof122
@@ -5053,65 +4970,70 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_122:
 		switch data[p] {
 		case 13:
-			goto st122
+			goto st101
 		case 32:
-			goto st122
-		case 34:
-			goto st123
-		case 45:
-			goto st133
-		case 48:
-			goto st134
-		case 91:
-			goto tr147
-		case 102:
-			goto st145
-		case 110:
-			goto st150
-		case 116:
-			goto st154
-		case 123:
-			goto tr151
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		switch {
-		case data[p] > 10:
-			if 49 <= data[p] && data[p] <= 57 {
-				goto st142
-			}
-		case data[p] >= 9:
-			goto st122
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
 		}
-		goto tr111
+		goto tr98
+	tr149:
+		p, err = skipFloatExp(data, p+1, pe)
+		goto st123
 	st123:
 		if p++; p == pe {
 			goto _test_eof123
 		}
 	st_case_123:
 		switch data[p] {
-		case 34:
-			goto st125
-		case 92:
-			goto st126
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		if data[p] <= 31 {
-			goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
 		}
-		goto st124
+		goto tr98
 	st124:
 		if p++; p == pe {
 			goto _test_eof124
 		}
 	st_case_124:
 		switch data[p] {
-		case 34:
-			goto st125
-		case 92:
-			goto st126
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 46:
+			goto tr148
+		case 69:
+			goto tr149
+		case 101:
+			goto tr149
+		case 125:
+			goto tr101
 		}
-		if data[p] <= 31 {
-			goto tr111
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st125
+			}
+		case data[p] >= 9:
+			goto st101
 		}
-		goto st124
+		goto tr98
 	st125:
 		if p++; p == pe {
 			goto _test_eof125
@@ -5119,285 +5041,235 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_125:
 		switch data[p] {
 		case 13:
-			goto st114
+			goto st101
 		case 32:
-			goto st114
+			goto st101
 		case 44:
-			goto st115
+			goto st102
+		case 46:
+			goto tr148
+		case 69:
+			goto tr149
+		case 101:
+			goto tr149
 		case 125:
-			goto tr114
+			goto tr101
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st125
+			}
+		case data[p] >= 9:
+			goto st101
 		}
-		goto tr111
-	tr114:
+		goto tr98
+	tr134:
 		{
-			top--
-			cs = stack[top]
-			goto _again
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 126
+				top++
+				goto st23
+			}
 		}
-		goto st220
-	st220:
-		if p++; p == pe {
-			goto _test_eof220
-		}
-	st_case_220:
-		goto st0
+		goto st126
 	st126:
 		if p++; p == pe {
 			goto _test_eof126
 		}
 	st_case_126:
 		switch data[p] {
-		case 34:
-			goto st127
-		case 47:
-			goto st127
-		case 92:
-			goto st127
-		case 98:
-			goto st127
-		case 102:
-			goto st127
-		case 110:
-			goto st127
-		case 114:
-			goto st127
-		case 116:
-			goto st127
-		case 117:
-			goto st128
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st127:
 		if p++; p == pe {
 			goto _test_eof127
 		}
 	st_case_127:
-		switch data[p] {
-		case 34:
-			goto st125
-		case 92:
-			goto st126
+		if data[p] == 97 {
+			goto st128
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st124
+		goto tr98
 	st128:
 		if p++; p == pe {
 			goto _test_eof128
 		}
 	st_case_128:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st129
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st129
-			}
-		default:
+		if data[p] == 108 {
 			goto st129
 		}
-		goto tr111
+		goto tr98
 	st129:
 		if p++; p == pe {
 			goto _test_eof129
 		}
 	st_case_129:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st130
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st130
-			}
-		default:
+		if data[p] == 115 {
 			goto st130
 		}
-		goto tr111
+		goto tr98
 	st130:
 		if p++; p == pe {
 			goto _test_eof130
 		}
 	st_case_130:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st131
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st131
-			}
-		default:
+		if data[p] == 101 {
 			goto st131
 		}
-		goto tr111
+		goto tr98
 	st131:
 		if p++; p == pe {
 			goto _test_eof131
 		}
 	st_case_131:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st132
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st132
-			}
-		default:
-			goto st132
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st132:
 		if p++; p == pe {
 			goto _test_eof132
 		}
 	st_case_132:
-		switch data[p] {
-		case 34:
-			goto st125
-		case 92:
-			goto st126
+		if data[p] == 117 {
+			goto st133
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st124
+		goto tr98
 	st133:
 		if p++; p == pe {
 			goto _test_eof133
 		}
 	st_case_133:
-		if data[p] == 48 {
+		if data[p] == 108 {
 			goto st134
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st142
-		}
-		goto tr111
+		goto tr98
 	st134:
 		if p++; p == pe {
 			goto _test_eof134
 		}
 	st_case_134:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
+		if data[p] == 108 {
 			goto st135
-		case 69:
-			goto st138
-		case 101:
-			goto st138
-		case 125:
-			goto tr114
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st135:
 		if p++; p == pe {
 			goto _test_eof135
 		}
 	st_case_135:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st136
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st136:
 		if p++; p == pe {
 			goto _test_eof136
 		}
 	st_case_136:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
-			goto st138
-		case 101:
-			goto st138
-		case 125:
-			goto tr114
+		if data[p] == 114 {
+			goto st137
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st137
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st137:
 		if p++; p == pe {
 			goto _test_eof137
 		}
 	st_case_137:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
+		if data[p] == 117 {
 			goto st138
-		case 101:
-			goto st138
-		case 125:
-			goto tr114
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st137
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st138:
 		if p++; p == pe {
 			goto _test_eof138
 		}
 	st_case_138:
-		switch data[p] {
-		case 43:
-			goto st139
-		case 45:
+		if data[p] == 101 {
 			goto st139
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st140
-		}
-		goto tr111
+		goto tr98
 	st139:
 		if p++; p == pe {
 			goto _test_eof139
 		}
 	st_case_139:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st140
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
+	tr138:
+		{
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 140
+				top++
+				goto st90
+			}
+		}
+		goto st140
 	st140:
 		if p++; p == pe {
 			goto _test_eof140
@@ -5405,274 +5277,314 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_140:
 		switch data[p] {
 		case 13:
-			goto st114
+			goto st101
 		case 32:
-			goto st114
+			goto st101
 		case 44:
-			goto st115
+			goto st102
 		case 125:
-			goto tr114
+			goto tr101
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st141
-			}
-		case data[p] >= 9:
-			goto st114
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
 		}
-		goto tr111
+		goto tr98
 	st141:
 		if p++; p == pe {
 			goto _test_eof141
 		}
 	st_case_141:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
+		case 34:
+			goto st142
+		case 47:
+			goto st142
+		case 92:
+			goto st142
+		case 98:
+			goto st142
+		case 102:
+			goto st142
+		case 110:
+			goto st142
+		case 114:
+			goto st142
+		case 116:
+			goto st142
+		case 117:
+			goto st143
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st141
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st142:
 		if p++; p == pe {
 			goto _test_eof142
 		}
 	st_case_142:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st135
-		case 69:
-			goto st138
-		case 101:
-			goto st138
-		case 125:
-			goto tr114
+		case 34:
+			goto st106
+		case 92:
+			goto st141
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st143
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st105
 	st143:
 		if p++; p == pe {
 			goto _test_eof143
 		}
 	st_case_143:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st135
-		case 69:
-			goto st138
-		case 101:
-			goto st138
-		case 125:
-			goto tr114
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st143
+				goto st144
 			}
-		case data[p] >= 9:
-			goto st114
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st144
+			}
+		default:
+			goto st144
 		}
-		goto tr111
-	tr147:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 144
-				top++
-				goto st26
-			}
-		}
-		goto st144
+		goto tr98
 	st144:
 		if p++; p == pe {
 			goto _test_eof144
 		}
 	st_case_144:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st145
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st145
+			}
+		default:
+			goto st145
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st145:
 		if p++; p == pe {
 			goto _test_eof145
 		}
 	st_case_145:
-		if data[p] == 97 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st146
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st146
+			}
+		default:
 			goto st146
 		}
-		goto tr111
+		goto tr98
 	st146:
 		if p++; p == pe {
 			goto _test_eof146
 		}
 	st_case_146:
-		if data[p] == 108 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st147
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st147
+			}
+		default:
 			goto st147
 		}
-		goto tr111
+		goto tr98
 	st147:
 		if p++; p == pe {
 			goto _test_eof147
 		}
 	st_case_147:
-		if data[p] == 115 {
-			goto st148
+		switch data[p] {
+		case 34:
+			goto st106
+		case 92:
+			goto st141
 		}
-		goto tr111
+		if data[p] <= 31 {
+			goto tr98
+		}
+		goto st105
 	st148:
 		if p++; p == pe {
 			goto _test_eof148
 		}
 	st_case_148:
-		if data[p] == 101 {
+		switch data[p] {
+		case 34:
 			goto st149
+		case 47:
+			goto st149
+		case 92:
+			goto st149
+		case 98:
+			goto st149
+		case 102:
+			goto st149
+		case 110:
+			goto st149
+		case 114:
+			goto st149
+		case 116:
+			goto st149
+		case 117:
+			goto st150
 		}
-		goto tr111
+		goto tr98
 	st149:
 		if p++; p == pe {
 			goto _test_eof149
 		}
 	st_case_149:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
+		case 34:
+			goto st100
+		case 92:
+			goto st148
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st99
 	st150:
 		if p++; p == pe {
 			goto _test_eof150
 		}
 	st_case_150:
-		if data[p] == 117 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st151
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st151
+			}
+		default:
 			goto st151
 		}
-		goto tr111
+		goto tr98
 	st151:
 		if p++; p == pe {
 			goto _test_eof151
 		}
 	st_case_151:
-		if data[p] == 108 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st152
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st152
+			}
+		default:
 			goto st152
 		}
-		goto tr111
+		goto tr98
 	st152:
 		if p++; p == pe {
 			goto _test_eof152
 		}
 	st_case_152:
-		if data[p] == 108 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st153
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st153
+			}
+		default:
 			goto st153
 		}
-		goto tr111
+		goto tr98
 	st153:
 		if p++; p == pe {
 			goto _test_eof153
 		}
 	st_case_153:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st154
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st154
+			}
+		default:
+			goto st154
 		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st154:
 		if p++; p == pe {
 			goto _test_eof154
 		}
 	st_case_154:
-		if data[p] == 114 {
-			goto st155
+		switch data[p] {
+		case 34:
+			goto st100
+		case 92:
+			goto st148
 		}
-		goto tr111
+		if data[p] <= 31 {
+			goto tr98
+		}
+		goto st99
 	st155:
 		if p++; p == pe {
 			goto _test_eof155
 		}
 	st_case_155:
-		if data[p] == 117 {
+		if data[p] == 48 {
 			goto st156
 		}
-		goto tr111
+		if 49 <= data[p] && data[p] <= 57 {
+			goto st159
+		}
+		goto tr98
 	st156:
 		if p++; p == pe {
 			goto _test_eof156
 		}
 	st_case_156:
-		if data[p] == 101 {
-			goto st157
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 101:
+			goto tr174
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
+	tr173:
+		p, err = skipFloatDec(data, p+1, pe)
+		goto st157
 	st157:
 		if p++; p == pe {
 			goto _test_eof157
@@ -5680,37 +5592,20 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_157:
 		switch data[p] {
 		case 13:
-			goto st114
+			goto st101
 		case 32:
-			goto st114
+			goto st101
 		case 44:
-			goto st115
+			goto st102
 		case 125:
-			goto tr114
+			goto tr101
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+			goto st101
 		}
-		goto tr111
-	tr151:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 158
-				top++
-				goto st103
-			}
-		}
+		goto tr98
+	tr174:
+		p, err = skipFloatExp(data, p+1, pe)
 		goto st158
 	st158:
 		if p++; p == pe {
@@ -5719,286 +5614,245 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_158:
 		switch data[p] {
 		case 13:
-			goto st114
+			goto st101
 		case 32:
-			goto st114
+			goto st101
 		case 44:
-			goto st115
+			goto st102
 		case 125:
-			goto tr114
+			goto tr101
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+			goto st101
 		}
-		goto tr111
+		goto tr98
 	st159:
 		if p++; p == pe {
 			goto _test_eof159
 		}
 	st_case_159:
 		switch data[p] {
-		case 34:
-			goto st160
-		case 47:
-			goto st160
-		case 92:
-			goto st160
-		case 98:
-			goto st160
-		case 102:
-			goto st160
-		case 110:
-			goto st160
-		case 114:
-			goto st160
-		case 116:
-			goto st160
-		case 117:
-			goto st161
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 101:
+			goto tr174
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st160
+			}
+		case data[p] >= 9:
+			goto st101
+		}
+		goto tr98
 	st160:
 		if p++; p == pe {
 			goto _test_eof160
 		}
 	st_case_160:
 		switch data[p] {
-		case 34:
-			goto st119
-		case 92:
-			goto st159
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 46:
+			goto tr173
+		case 69:
+			goto tr174
+		case 101:
+			goto tr174
+		case 125:
+			goto tr101
 		}
-		if data[p] <= 31 {
-			goto tr111
+		switch {
+		case data[p] > 10:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st160
+			}
+		case data[p] >= 9:
+			goto st101
 		}
-		goto st118
+		goto tr98
+	tr112:
+		{
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 161
+				top++
+				goto st23
+			}
+		}
+		goto st161
 	st161:
 		if p++; p == pe {
 			goto _test_eof161
 		}
 	st_case_161:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st162
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st162
-			}
-		default:
-			goto st162
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st162:
 		if p++; p == pe {
 			goto _test_eof162
 		}
 	st_case_162:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st163
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st163
-			}
-		default:
+		if data[p] == 97 {
 			goto st163
 		}
-		goto tr111
+		goto tr98
 	st163:
 		if p++; p == pe {
 			goto _test_eof163
 		}
 	st_case_163:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st164
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st164
-			}
-		default:
+		if data[p] == 108 {
 			goto st164
 		}
-		goto tr111
+		goto tr98
 	st164:
 		if p++; p == pe {
 			goto _test_eof164
 		}
 	st_case_164:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st165
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st165
-			}
-		default:
+		if data[p] == 115 {
 			goto st165
 		}
-		goto tr111
+		goto tr98
 	st165:
 		if p++; p == pe {
 			goto _test_eof165
 		}
 	st_case_165:
-		switch data[p] {
-		case 34:
-			goto st119
-		case 92:
-			goto st159
+		if data[p] == 101 {
+			goto st166
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st118
+		goto tr98
 	st166:
 		if p++; p == pe {
 			goto _test_eof166
 		}
 	st_case_166:
 		switch data[p] {
-		case 34:
-			goto st167
-		case 47:
-			goto st167
-		case 92:
-			goto st167
-		case 98:
-			goto st167
-		case 102:
-			goto st167
-		case 110:
-			goto st167
-		case 114:
-			goto st167
-		case 116:
-			goto st167
-		case 117:
-			goto st168
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st167:
 		if p++; p == pe {
 			goto _test_eof167
 		}
 	st_case_167:
-		switch data[p] {
-		case 34:
-			goto st113
-		case 92:
-			goto st166
+		if data[p] == 117 {
+			goto st168
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st112
+		goto tr98
 	st168:
 		if p++; p == pe {
 			goto _test_eof168
 		}
 	st_case_168:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st169
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st169
-			}
-		default:
+		if data[p] == 108 {
 			goto st169
 		}
-		goto tr111
+		goto tr98
 	st169:
 		if p++; p == pe {
 			goto _test_eof169
 		}
 	st_case_169:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st170
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st170
-			}
-		default:
+		if data[p] == 108 {
 			goto st170
 		}
-		goto tr111
+		goto tr98
 	st170:
 		if p++; p == pe {
 			goto _test_eof170
 		}
 	st_case_170:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st171
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st171
-			}
-		default:
-			goto st171
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st171:
 		if p++; p == pe {
 			goto _test_eof171
 		}
 	st_case_171:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st172
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st172
-			}
-		default:
+		if data[p] == 114 {
 			goto st172
 		}
-		goto tr111
+		goto tr98
 	st172:
 		if p++; p == pe {
 			goto _test_eof172
 		}
 	st_case_172:
-		switch data[p] {
-		case 34:
-			goto st113
-		case 92:
-			goto st166
+		if data[p] == 117 {
+			goto st173
 		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st112
+		goto tr98
 	st173:
 		if p++; p == pe {
 			goto _test_eof173
 		}
 	st_case_173:
-		if data[p] == 48 {
+		if data[p] == 101 {
 			goto st174
 		}
-		if 49 <= data[p] && data[p] <= 57 {
-			goto st182
-		}
-		goto tr111
+		goto tr98
 	st174:
 		if p++; p == pe {
 			goto _test_eof174
@@ -6006,574 +5860,185 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	st_case_174:
 		switch data[p] {
 		case 13:
-			goto st114
+			goto st101
 		case 32:
-			goto st114
+			goto st101
 		case 44:
-			goto st115
-		case 46:
-			goto st175
-		case 69:
-			goto st178
-		case 101:
-			goto st178
+			goto st102
 		case 125:
-			goto tr114
+			goto tr101
 		}
 		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
+			goto st101
 		}
-		goto tr111
+		goto tr98
+	tr116:
+		{
+			if top == skipMaxDepth {
+				err = errMaxDepth
+				{
+					p++
+					cs = 0
+					goto _out
+				}
+			}
+			if top+1 >= len(stack) {
+				stack = append(stack, make([]int, 1+top-len(stack))...)
+			}
+			{
+				stack[top] = 175
+				top++
+				goto st90
+			}
+		}
+		goto st175
 	st175:
 		if p++; p == pe {
 			goto _test_eof175
 		}
 	st_case_175:
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st176
+		switch data[p] {
+		case 13:
+			goto st101
+		case 32:
+			goto st101
+		case 44:
+			goto st102
+		case 125:
+			goto tr101
 		}
-		goto tr111
+		if 9 <= data[p] && data[p] <= 10 {
+			goto st101
+		}
+		goto tr98
 	st176:
 		if p++; p == pe {
 			goto _test_eof176
 		}
 	st_case_176:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
+		case 34:
+			goto st177
+		case 47:
+			goto st177
+		case 92:
+			goto st177
+		case 98:
+			goto st177
+		case 102:
+			goto st177
+		case 110:
+			goto st177
+		case 114:
+			goto st177
+		case 116:
+			goto st177
+		case 117:
 			goto st178
-		case 101:
-			goto st178
-		case 125:
-			goto tr114
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st177
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
+		goto tr98
 	st177:
 		if p++; p == pe {
 			goto _test_eof177
 		}
 	st_case_177:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 69:
-			goto st178
-		case 101:
-			goto st178
-		case 125:
-			goto tr114
+		case 34:
+			goto st94
+		case 92:
+			goto st176
 		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st177
-			}
-		case data[p] >= 9:
-			goto st114
+		if data[p] <= 31 {
+			goto tr98
 		}
-		goto tr111
+		goto st93
 	st178:
 		if p++; p == pe {
 			goto _test_eof178
 		}
 	st_case_178:
-		switch data[p] {
-		case 43:
-			goto st179
-		case 45:
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st179
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st179
+			}
+		default:
 			goto st179
 		}
-		if 48 <= data[p] && data[p] <= 57 {
-			goto st180
-		}
-		goto tr111
+		goto tr98
 	st179:
 		if p++; p == pe {
 			goto _test_eof179
 		}
 	st_case_179:
-		if 48 <= data[p] && data[p] <= 57 {
+		switch {
+		case data[p] < 65:
+			if 48 <= data[p] && data[p] <= 57 {
+				goto st180
+			}
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st180
+			}
+		default:
 			goto st180
 		}
-		goto tr111
+		goto tr98
 	st180:
 		if p++; p == pe {
 			goto _test_eof180
 		}
 	st_case_180:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
 				goto st181
 			}
-		case data[p] >= 9:
-			goto st114
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st181
+			}
+		default:
+			goto st181
 		}
-		goto tr111
+		goto tr98
 	st181:
 		if p++; p == pe {
 			goto _test_eof181
 		}
 	st_case_181:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
 		switch {
-		case data[p] > 10:
+		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto st181
+				goto st182
 			}
-		case data[p] >= 9:
-			goto st114
+		case data[p] > 70:
+			if 97 <= data[p] && data[p] <= 102 {
+				goto st182
+			}
+		default:
+			goto st182
 		}
-		goto tr111
+		goto tr98
 	st182:
 		if p++; p == pe {
 			goto _test_eof182
 		}
 	st_case_182:
 		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st175
-		case 69:
-			goto st178
-		case 101:
-			goto st178
-		case 125:
-			goto tr114
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st183
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
-	st183:
-		if p++; p == pe {
-			goto _test_eof183
-		}
-	st_case_183:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 46:
-			goto st175
-		case 69:
-			goto st178
-		case 101:
-			goto st178
-		case 125:
-			goto tr114
-		}
-		switch {
-		case data[p] > 10:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st183
-			}
-		case data[p] >= 9:
-			goto st114
-		}
-		goto tr111
-	tr125:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 184
-				top++
-				goto st26
-			}
-		}
-		goto st184
-	st184:
-		if p++; p == pe {
-			goto _test_eof184
-		}
-	st_case_184:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
-	st185:
-		if p++; p == pe {
-			goto _test_eof185
-		}
-	st_case_185:
-		if data[p] == 97 {
-			goto st186
-		}
-		goto tr111
-	st186:
-		if p++; p == pe {
-			goto _test_eof186
-		}
-	st_case_186:
-		if data[p] == 108 {
-			goto st187
-		}
-		goto tr111
-	st187:
-		if p++; p == pe {
-			goto _test_eof187
-		}
-	st_case_187:
-		if data[p] == 115 {
-			goto st188
-		}
-		goto tr111
-	st188:
-		if p++; p == pe {
-			goto _test_eof188
-		}
-	st_case_188:
-		if data[p] == 101 {
-			goto st189
-		}
-		goto tr111
-	st189:
-		if p++; p == pe {
-			goto _test_eof189
-		}
-	st_case_189:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
-	st190:
-		if p++; p == pe {
-			goto _test_eof190
-		}
-	st_case_190:
-		if data[p] == 117 {
-			goto st191
-		}
-		goto tr111
-	st191:
-		if p++; p == pe {
-			goto _test_eof191
-		}
-	st_case_191:
-		if data[p] == 108 {
-			goto st192
-		}
-		goto tr111
-	st192:
-		if p++; p == pe {
-			goto _test_eof192
-		}
-	st_case_192:
-		if data[p] == 108 {
-			goto st193
-		}
-		goto tr111
-	st193:
-		if p++; p == pe {
-			goto _test_eof193
-		}
-	st_case_193:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
-	st194:
-		if p++; p == pe {
-			goto _test_eof194
-		}
-	st_case_194:
-		if data[p] == 114 {
-			goto st195
-		}
-		goto tr111
-	st195:
-		if p++; p == pe {
-			goto _test_eof195
-		}
-	st_case_195:
-		if data[p] == 117 {
-			goto st196
-		}
-		goto tr111
-	st196:
-		if p++; p == pe {
-			goto _test_eof196
-		}
-	st_case_196:
-		if data[p] == 101 {
-			goto st197
-		}
-		goto tr111
-	st197:
-		if p++; p == pe {
-			goto _test_eof197
-		}
-	st_case_197:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
-	tr129:
-		{
-			if top == skipMaxDepth {
-				err = errMaxDepth
-				{
-					p++
-					cs = 0
-					goto _out
-				}
-			}
-			if top+1 >= len(stack) {
-				stack = append(stack, make([]int, 1+top-len(stack))...)
-			}
-			{
-				stack[top] = 198
-				top++
-				goto st103
-			}
-		}
-		goto st198
-	st198:
-		if p++; p == pe {
-			goto _test_eof198
-		}
-	st_case_198:
-		switch data[p] {
-		case 13:
-			goto st114
-		case 32:
-			goto st114
-		case 44:
-			goto st115
-		case 125:
-			goto tr114
-		}
-		if 9 <= data[p] && data[p] <= 10 {
-			goto st114
-		}
-		goto tr111
-	st199:
-		if p++; p == pe {
-			goto _test_eof199
-		}
-	st_case_199:
-		switch data[p] {
 		case 34:
-			goto st200
-		case 47:
-			goto st200
+			goto st94
 		case 92:
-			goto st200
-		case 98:
-			goto st200
-		case 102:
-			goto st200
-		case 110:
-			goto st200
-		case 114:
-			goto st200
-		case 116:
-			goto st200
-		case 117:
-			goto st201
-		}
-		goto tr111
-	st200:
-		if p++; p == pe {
-			goto _test_eof200
-		}
-	st_case_200:
-		switch data[p] {
-		case 34:
-			goto st107
-		case 92:
-			goto st199
+			goto st176
 		}
 		if data[p] <= 31 {
-			goto tr111
+			goto tr98
 		}
-		goto st106
-	st201:
-		if p++; p == pe {
-			goto _test_eof201
-		}
-	st_case_201:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st202
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st202
-			}
-		default:
-			goto st202
-		}
-		goto tr111
-	st202:
-		if p++; p == pe {
-			goto _test_eof202
-		}
-	st_case_202:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st203
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st203
-			}
-		default:
-			goto st203
-		}
-		goto tr111
-	st203:
-		if p++; p == pe {
-			goto _test_eof203
-		}
-	st_case_203:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st204
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st204
-			}
-		default:
-			goto st204
-		}
-		goto tr111
-	st204:
-		if p++; p == pe {
-			goto _test_eof204
-		}
-	st_case_204:
-		switch {
-		case data[p] < 65:
-			if 48 <= data[p] && data[p] <= 57 {
-				goto st205
-			}
-		case data[p] > 70:
-			if 97 <= data[p] && data[p] <= 102 {
-				goto st205
-			}
-		default:
-			goto st205
-		}
-		goto tr111
-	st205:
-		if p++; p == pe {
-			goto _test_eof205
-		}
-	st_case_205:
-		switch data[p] {
-		case 34:
-			goto st107
-		case 92:
-			goto st199
-		}
-		if data[p] <= 31 {
-			goto tr111
-		}
-		goto st106
+		goto st93
 	st_out:
 	_test_eof1:
 		cs = 1
@@ -6587,8 +6052,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof4:
 		cs = 4
 		goto _test_eof
-	_test_eof206:
-		cs = 206
+	_test_eof183:
+		cs = 183
 		goto _test_eof
 	_test_eof5:
 		cs = 5
@@ -6614,17 +6079,26 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof12:
 		cs = 12
 		goto _test_eof
-	_test_eof207:
-		cs = 207
+	_test_eof184:
+		cs = 184
+		goto _test_eof
+	_test_eof185:
+		cs = 185
+		goto _test_eof
+	_test_eof186:
+		cs = 186
+		goto _test_eof
+	_test_eof187:
+		cs = 187
+		goto _test_eof
+	_test_eof188:
+		cs = 188
+		goto _test_eof
+	_test_eof189:
+		cs = 189
 		goto _test_eof
 	_test_eof13:
 		cs = 13
-		goto _test_eof
-	_test_eof208:
-		cs = 208
-		goto _test_eof
-	_test_eof209:
-		cs = 209
 		goto _test_eof
 	_test_eof14:
 		cs = 14
@@ -6632,23 +6106,11 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof15:
 		cs = 15
 		goto _test_eof
-	_test_eof210:
-		cs = 210
-		goto _test_eof
-	_test_eof211:
-		cs = 211
-		goto _test_eof
-	_test_eof212:
-		cs = 212
-		goto _test_eof
-	_test_eof213:
-		cs = 213
-		goto _test_eof
-	_test_eof214:
-		cs = 214
-		goto _test_eof
 	_test_eof16:
 		cs = 16
+		goto _test_eof
+	_test_eof190:
+		cs = 190
 		goto _test_eof
 	_test_eof17:
 		cs = 17
@@ -6659,8 +6121,8 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof19:
 		cs = 19
 		goto _test_eof
-	_test_eof215:
-		cs = 215
+	_test_eof191:
+		cs = 191
 		goto _test_eof
 	_test_eof20:
 		cs = 20
@@ -6671,8 +6133,11 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof22:
 		cs = 22
 		goto _test_eof
-	_test_eof216:
-		cs = 216
+	_test_eof192:
+		cs = 192
+		goto _test_eof
+	_test_eof193:
+		cs = 193
 		goto _test_eof
 	_test_eof23:
 		cs = 23
@@ -6682,12 +6147,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		goto _test_eof
 	_test_eof25:
 		cs = 25
-		goto _test_eof
-	_test_eof217:
-		cs = 217
-		goto _test_eof
-	_test_eof218:
-		cs = 218
 		goto _test_eof
 	_test_eof26:
 		cs = 26
@@ -6713,6 +6172,9 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof33:
 		cs = 33
 		goto _test_eof
+	_test_eof194:
+		cs = 194
+		goto _test_eof
 	_test_eof34:
 		cs = 34
 		goto _test_eof
@@ -6721,9 +6183,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		goto _test_eof
 	_test_eof36:
 		cs = 36
-		goto _test_eof
-	_test_eof219:
-		cs = 219
 		goto _test_eof
 	_test_eof37:
 		cs = 37
@@ -6953,6 +6412,9 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof112:
 		cs = 112
 		goto _test_eof
+	_test_eof195:
+		cs = 195
+		goto _test_eof
 	_test_eof113:
 		cs = 113
 		goto _test_eof
@@ -6991,9 +6453,6 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 		goto _test_eof
 	_test_eof125:
 		cs = 125
-		goto _test_eof
-	_test_eof220:
-		cs = 220
 		goto _test_eof
 	_test_eof126:
 		cs = 126
@@ -7166,86 +6625,17 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 	_test_eof182:
 		cs = 182
 		goto _test_eof
-	_test_eof183:
-		cs = 183
-		goto _test_eof
-	_test_eof184:
-		cs = 184
-		goto _test_eof
-	_test_eof185:
-		cs = 185
-		goto _test_eof
-	_test_eof186:
-		cs = 186
-		goto _test_eof
-	_test_eof187:
-		cs = 187
-		goto _test_eof
-	_test_eof188:
-		cs = 188
-		goto _test_eof
-	_test_eof189:
-		cs = 189
-		goto _test_eof
-	_test_eof190:
-		cs = 190
-		goto _test_eof
-	_test_eof191:
-		cs = 191
-		goto _test_eof
-	_test_eof192:
-		cs = 192
-		goto _test_eof
-	_test_eof193:
-		cs = 193
-		goto _test_eof
-	_test_eof194:
-		cs = 194
-		goto _test_eof
-	_test_eof195:
-		cs = 195
-		goto _test_eof
-	_test_eof196:
-		cs = 196
-		goto _test_eof
-	_test_eof197:
-		cs = 197
-		goto _test_eof
-	_test_eof198:
-		cs = 198
-		goto _test_eof
-	_test_eof199:
-		cs = 199
-		goto _test_eof
-	_test_eof200:
-		cs = 200
-		goto _test_eof
-	_test_eof201:
-		cs = 201
-		goto _test_eof
-	_test_eof202:
-		cs = 202
-		goto _test_eof
-	_test_eof203:
-		cs = 203
-		goto _test_eof
-	_test_eof204:
-		cs = 204
-		goto _test_eof
-	_test_eof205:
-		cs = 205
-		goto _test_eof
 
 	_test_eof:
 		{
 		}
 		if p == eof {
 			switch cs {
-			case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25:
+			case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22:
 
 				return p, stack, errNoValidToken
 
-			case 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102:
+			case 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89:
 				err = errUnexpectedEOF
 				{
 					p++
@@ -7258,7 +6648,7 @@ func skipValue(data []byte, stack []int) (int, []int, error) {
 					cs = 0
 					goto _out
 				}
-			case 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205:
+			case 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182:
 				err = errUnexpectedEOF
 				{
 					p++


### PR DESCRIPTION
This speeds up skipping long numbers at the expense of double reading the token after a number. This will slightly slow skipping objects and arrays with a lot of short number values.