### PR TITLE
Use pointers for string buffers

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -211,14 +211,52 @@ benchLoop:
 }
 
 func BenchmarkReadString(b *testing.B) {
-	data := []byte(`"hello this is a string of somewhat normal length"`)
+	simpleString := []byte(`"hello this is a string of somewhat normal length"`)
+	complexString := []byte(`"@aym0566x \n\n名前:前田あゆみ\n第一印象:なんか怖っ！\n今の印象:とりあえずキモい。噛み合わない\n好きなところ:ぶすでキモいとこ😋✨✨\n思い出:んーーー、ありすぎ😊❤️\nLINE交換できる？:あぁ……ごめん✋\nトプ画をみて:照れますがな😘✨\n一言:お前は一生もんのダチ💖"`)
 	var err error
-	b.ReportAllocs()
-	b.SetBytes(int64(len(data)))
-	for i := 0; i < b.N; i++ {
-		benchString, benchInt, err = ReadString(data, nil)
-	}
-	require.NoError(b, err)
+
+	b.Run("simple string", func(b *testing.B) {
+		b.Run("nil buf", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(simpleString)))
+			for i := 0; i < b.N; i++ {
+				benchString, benchInt, err = ReadString(simpleString, nil)
+			}
+			require.NoError(b, err)
+		})
+
+		b.Run("with buf", func(b *testing.B) {
+			var buf []byte
+			b.ReportAllocs()
+			b.SetBytes(int64(len(simpleString)))
+			for i := 0; i < b.N; i++ {
+				benchString, benchInt, err = ReadString(simpleString, buf)
+			}
+			require.NoError(b, err)
+		})
+	})
+
+	b.Run("complex string", func(b *testing.B) {
+		b.Run("nil buf", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(complexString)))
+			for i := 0; i < b.N; i++ {
+				benchString, benchInt, err = ReadString(complexString, nil)
+			}
+			require.NoError(b, err)
+		})
+
+		b.Run("with buf", func(b *testing.B) {
+			var buf []byte
+			b.ReportAllocs()
+			b.SetBytes(int64(len(complexString)))
+			for i := 0; i < b.N; i++ {
+				benchString, benchInt, err = ReadString(complexString, buf)
+			}
+			require.NoError(b, err)
+		})
+	})
+
 }
 
 func BenchmarkDecodeString(b *testing.B) {

--- a/bench_test.go
+++ b/bench_test.go
@@ -230,7 +230,7 @@ func BenchmarkReadString(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(simpleString)))
 			for i := 0; i < b.N; i++ {
-				benchString, benchInt, err = ReadString(simpleString, buf)
+				benchString, benchInt, err = ReadString(simpleString, &buf)
 			}
 			require.NoError(b, err)
 		})
@@ -251,12 +251,11 @@ func BenchmarkReadString(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(complexString)))
 			for i := 0; i < b.N; i++ {
-				benchString, benchInt, err = ReadString(complexString, buf)
+				benchString, benchInt, err = ReadString(complexString, &buf)
 			}
 			require.NoError(b, err)
 		})
 	})
-
 }
 
 func BenchmarkDecodeString(b *testing.B) {
@@ -264,9 +263,9 @@ func BenchmarkDecodeString(b *testing.B) {
 	var err error
 	b.ReportAllocs()
 	b.SetBytes(int64(len(data)))
-	stringBuf := make([]byte, len(data)*4)
+	var stringBuf []byte
 	for i := 0; i < b.N; i++ {
-		benchInt, err = DecodeString(data, &benchString, stringBuf)
+		benchInt, err = DecodeString(data, &benchString, &stringBuf)
 	}
 	require.NoError(b, err)
 }

--- a/decode.go
+++ b/decode.go
@@ -127,7 +127,7 @@ func decodeUintCompat(data []byte, v *uint) (p int, err error) {
 
 // DecodeString reads a string value at the beginning of data. If data begins with null, v is untouched.
 // If buf is not nil, it will be used as a working for building the string value.
-func DecodeString(data []byte, v *string, buf []byte) (p int, err error) {
+func DecodeString(data []byte, v *string, buf *[]byte) (p int, err error) {
 	var val string
 	val, p, err = ReadString(data, buf)
 	if err != nil {

--- a/fuzzers.go
+++ b/fuzzers.go
@@ -209,6 +209,13 @@ func fuzzReadString(data []byte) (int, error) {
 	got, gotP, gotErr := ReadString(data, nil)
 	got = StdLibCompatibleString(got)
 	err := checkFuzzResults(want, got, wantP, gotP, wantErr, gotErr)
+	if err != nil {
+		return 0, err
+	}
+	// try again with a dirty buffer
+	got, gotP, gotErr = ReadString(data, dirtyStringBuffer())
+	got = StdLibCompatibleString(got)
+	err = checkFuzzResults(want, got, wantP, gotP, wantErr, gotErr)
 	return 0, err
 }
 
@@ -218,6 +225,13 @@ func fuzzDecodeString(data []byte) (int, error) {
 	gotP, gotErr := DecodeString(data, &got, nil)
 	got = StdLibCompatibleString(got)
 	err := checkFuzzResults(want, got, wantP, gotP, wantErr, gotErr)
+	if err != nil {
+		return 0, err
+	}
+	// try again with a dirty buffer
+	gotP, gotErr = DecodeString(data, &got, dirtyStringBuffer())
+	got = StdLibCompatibleString(got)
+	err = checkFuzzResults(want, got, wantP, gotP, wantErr, gotErr)
 	return 0, err
 }
 

--- a/testutil.go
+++ b/testutil.go
@@ -203,3 +203,8 @@ func ifaceCompare(want, got interface{}, path []string) error {
 		return newPathErr(path, "unhandled type %T", wantVal)
 	}
 }
+
+func dirtyStringBuffer() *[]byte {
+	buf := []byte(`this is a dirty buffer`)
+	return &buf
+}


### PR DESCRIPTION
This makes it easier to reuse buffers for ReadString and DecodeString